### PR TITLE
ci: do an apt-get update before trying to install things

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
                   go-version: ${{ matrix.go-version }}
             - name: install dependencies
               run: |
+                  sudo apt-get update
                   sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev libseccomp-dev libpam-dev bats parallel
                   GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
                   sudo cp ~/go/bin/umoci /usr/bin


### PR DESCRIPTION
We are getting:

E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/p/pam/libpam0g-dev_1.3.1-5ubuntu4.2_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.

in

https://github.com/anuvu/stacker/runs/3871772525

presumably because libpam has been updated but the apt-cache from the
github actions image has not. let's do the update manually so we don't hit
this.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>