### PR TITLE
unpriv-setup: don't try to resolve username from uid

### DIFF
--- a/cmd/unpriv-setup.go
+++ b/cmd/unpriv-setup.go
@@ -26,6 +26,11 @@ var unprivSetupCmd = cli.Command{
 			Usage: "the group to do setup for (defaults to $SUDO_GID from env)",
 			Value: os.Getenv("SUDO_GID"),
 		},
+		cli.StringFlag{
+			Name:  "username",
+			Usage: "the username to do setup for (defaults to $SUDO_USER from env)",
+			Value: os.Getenv("SUDO_USER"),
+		},
 	},
 }
 
@@ -36,6 +41,10 @@ func beforeUnprivSetup(ctx *cli.Context) error {
 
 	if ctx.String("gid") == "" {
 		return errors.Errorf("please specify --gid or run unpriv-setup with sudo")
+	}
+
+	if ctx.String("username") == "" {
+		return errors.Errorf("please specify --username or run unpriv-setup with sudo")
 	}
 
 	return nil
@@ -77,7 +86,9 @@ func doUnprivSetup(ctx *cli.Context) error {
 		return err
 	}
 
-	err = stacker.UnprivSetup(config, uid, gid)
+	username := ctx.String("username")
+
+	err = stacker.UnprivSetup(config, username, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/storage.go
+++ b/storage.go
@@ -162,8 +162,8 @@ func NewStorage(c types.StackerConfig) (types.Storage, error) {
 	return openStorage(c, c.StorageType)
 }
 
-func UnprivSetup(c types.StackerConfig, uid, gid int) error {
-	err := storage.UidmapSetup(uid, gid)
+func UnprivSetup(c types.StackerConfig, username string, uid, gid int) error {
+	err := storage.UidmapSetup(username, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/storage/unpriv-setup.go
+++ b/storage/unpriv-setup.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"strconv"
 	"strings"
 
@@ -77,18 +76,13 @@ func addSpecificEntries(file string, name string, currentId int) error {
 	return errors.Wrapf(err, "couldn't write %s", file)
 }
 
-func addEtcEntriesIfNecessary(uid int, gid int) error {
-	currentUser, err := user.LookupId(fmt.Sprintf("%d", uid))
-	if err != nil {
-		return errors.Wrapf(err, "couldn't find user for %d", uid)
-	}
-
-	err = addSpecificEntries("/etc/subuid", currentUser.Username, uid)
+func addEtcEntriesIfNecessary(username string, uid int, gid int) error {
+	err := addSpecificEntries("/etc/subuid", username, uid)
 	if err != nil {
 		return err
 	}
 
-	err = addSpecificEntries("/etc/subgid", currentUser.Username, gid)
+	err = addSpecificEntries("/etc/subgid", username, gid)
 	if err != nil {
 		return err
 	}
@@ -96,7 +90,7 @@ func addEtcEntriesIfNecessary(uid int, gid int) error {
 	return nil
 }
 
-func UidmapSetup(uid, gid int) error {
+func UidmapSetup(username string, uid, gid int) error {
 	warnAboutNewuidmap()
-	return addEtcEntriesIfNecessary(uid, gid)
+	return addEtcEntriesIfNecessary(username, uid, gid)
 }


### PR DESCRIPTION
The problem here is that os/user.LookupId() will fail if a uid isn't in
/etc/passwd:

https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/os/user/lookup_unix.go;l=240

which is a reasonably common situation with enterprise deployments, network
filesystems, etc.

However, in all these cases I'm aware of, people are doing unpriv-setup via
sudo, and not passing explicit uids and gids, so we can pull the username
out of sudo as well.

For anyone who *was* explicitly passing uids and gids, they probably know
what --username to pass as well. We could do some backwards compat
LookupId() if username == "" for those folks if they do end up existing.
But for now let's just punt.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>