### PR TITLE
unpriv-setup: really don't run in a userns

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -258,7 +258,7 @@ func main() {
 		stackerlog.FilterNonStackerLogs(handler, logLevel)
 		stackerlog.Debugf("stacker version %s", version)
 
-		if !ctx.Bool("internal-userns") && len(ctx.Args()) >= 1 && ctx.Args()[0] != "unpriv-stacker" {
+		if !ctx.Bool("internal-userns") && len(ctx.Args()) >= 1 && ctx.Args()[0] != "unpriv-setup" {
 			binary, err := os.Readlink("/proc/self/exe")
 			if err != nil {
 				return err


### PR DESCRIPTION
4f112bfa303e ("unpriv-setup: don't run inside a userns") made a typo in the
test... let's fix that.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>