### PR TITLE
storage: add a locking mechanism

### DIFF
--- a/btrfs/btrfs.go
+++ b/btrfs/btrfs.go
@@ -320,7 +320,8 @@ func (b *btrfs) Delete(source string) error {
 
 func (b *btrfs) Detach() error {
 	if b.needsUmount {
-		err := syscall.Unmount(b.c.RootFSDir, 0)
+		// Need to use DETACH here because we still hold the rootfs .lock file.
+		err := syscall.Unmount(b.c.RootFSDir, syscall.MNT_DETACH)
 		err2 := os.RemoveAll(b.c.RootFSDir)
 		if err != nil {
 			return err
@@ -391,7 +392,8 @@ func (b *btrfs) Clean() error {
 			return errors.Errorf("can't fully clean btrfs from userns (try stacker clean ... as root)")
 		}
 
-		umountErr = errors.Wrapf(syscall.Unmount(b.c.RootFSDir, 0), "unable to umount rootfs")
+		// Need to use DETACH here because we still hold the rootfs .lock file.
+		umountErr = errors.Wrapf(syscall.Unmount(b.c.RootFSDir, syscall.MNT_DETACH), "unable to umount rootfs")
 		if err = os.RemoveAll(loopback); err != nil {
 			log.Infof("failed removing btrfs loopback file: %v", err)
 		}

--- a/build.go
+++ b/build.go
@@ -533,13 +533,14 @@ func (b *Builder) Build(s types.Storage, file string) error {
 func (b *Builder) BuildMultiple(paths []string) error {
 	opts := b.opts
 
-	s, err := NewStorage(opts.Config)
+	s, locks, err := NewStorage(opts.Config)
 	if err != nil {
 		return err
 	}
 	if !opts.LeaveUnladen {
 		defer s.Detach()
 	}
+	defer locks.Unlock()
 
 	// Read all the stacker recipes
 	stackerFiles, err := types.NewStackerFiles(paths, append(opts.Substitute, b.opts.Config.Substitutions()...))

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -36,11 +36,12 @@ you must specify a tag.`,
 }
 
 func doChroot(ctx *cli.Context) error {
-	s, err := stacker.NewStorage(config)
+	s, locks, err := stacker.NewStorage(config)
 	if err != nil {
 		return err
 	}
 	defer s.Detach()
+	defer locks.Unlock()
 
 	tag := ""
 	if len(ctx.Args()) > 0 {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -25,7 +25,7 @@ func doClean(ctx *cli.Context) error {
 	fail := false
 
 	if _, err := os.Stat(config.RootFSDir); !os.IsNotExist(err) {
-		s, err := stacker.NewStorage(config)
+		s, locks, err := stacker.NewStorage(config)
 		if err != nil {
 			return err
 		}
@@ -35,6 +35,7 @@ func doClean(ctx *cli.Context) error {
 			log.Infof("problem cleaning roots %v", err)
 			fail = true
 		}
+		locks.Unlock()
 	}
 
 	if err := os.RemoveAll(config.OCIDir); err != nil {

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -12,10 +12,11 @@ var gcCmd = cli.Command{
 }
 
 func doGC(ctx *cli.Context) error {
-	s, err := stacker.NewStorage(config)
+	s, locks, err := stacker.NewStorage(config)
 	if err != nil {
 		return err
 	}
 	defer s.Detach()
+	defer locks.Unlock()
 	return s.GC()
 }

--- a/cmd/grab.go
+++ b/cmd/grab.go
@@ -21,11 +21,12 @@ var grabCmd = cli.Command{
 }
 
 func doGrab(ctx *cli.Context) error {
-	s, err := stacker.NewStorage(config)
+	s, locks, err := stacker.NewStorage(config)
 	if err != nil {
 		return err
 	}
 	defer s.Detach()
+	defer locks.Unlock()
 
 	parts := strings.SplitN(ctx.Args().First(), ":", 2)
 	if len(parts) < 2 {

--- a/lock.go
+++ b/lock.go
@@ -1,0 +1,127 @@
+package stacker
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/anuvu/stacker/types"
+	"github.com/pkg/errors"
+)
+
+func findLock(st *syscall.Stat_t) error {
+	content, err := ioutil.ReadFile("/proc/locks")
+	if err != nil {
+		return errors.Wrapf(err, "failed to read locks file")
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		if len(line) == 0 {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			return errors.Errorf("invalid lock file entry %s", line)
+		}
+
+		entries := strings.Split(fields[5], ":")
+		if len(entries) != 3 {
+			return errors.Errorf("invalid lock file field %s", fields[5])
+		}
+
+		/*
+		 * XXX: the kernel prints "fd:01:$ino" for some (all?) locks,
+		 * even though the man page we should be able to use fields 0
+		 * and 1 as major and minor device types. Let's just ignore
+		 * these.
+		 */
+
+		ino, err := strconv.ParseUint(entries[2], 10, 64)
+		if err != nil {
+			return errors.Wrapf(err, "invalid ino %s", entries[2])
+		}
+
+		if st.Ino != ino {
+			continue
+		}
+
+		pid := fields[4]
+		content, err := ioutil.ReadFile(path.Join("/proc", pid, "cmdline"))
+		if err != nil {
+			return errors.Errorf("lock owned by pid %s", pid)
+		}
+
+		content = bytes.Replace(content, []byte{0}, []byte{' '}, -1)
+		return errors.Errorf("lock owned by pid %s (%s)", pid, string(content))
+	}
+
+	return errors.Errorf("couldn't find who owns the lock")
+}
+
+func acquireLock(p string) (*os.File, error) {
+	lockfile, err := os.Create(p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't create lockfile %s", p)
+	}
+
+	lockMode := syscall.LOCK_EX
+
+	lockErr := syscall.Flock(int(lockfile.Fd()), lockMode|syscall.LOCK_NB)
+	if lockErr == nil {
+		return lockfile, nil
+	}
+
+	fi, err := lockfile.Stat()
+	lockfile.Close()
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't lock or stat lockfile %s", p)
+	}
+
+	owner := findLock(fi.Sys().(*syscall.Stat_t))
+	return nil, errors.Wrapf(lockErr, "couldn't acquire lock on %s: %v", p, owner)
+}
+
+const lockPath = ".lock"
+
+type StackerLocks struct {
+	stackerDir, rootsDir *os.File
+}
+
+func (ls *StackerLocks) Unlock() {
+	// TODO: it would be good to lock the OCI dir here, because I can
+	// imagine two people trying to output stuff to the same directory.
+	// However, that screws with umoci, because it sees an empty dir as an
+	// invalid image. the bug we're trying to fix <hair on fire>right
+	// now</hair on fire> is multiple invocations on a roots dir, so this
+	// is good enough.
+	for _, lock := range []*os.File{ls.stackerDir, ls.rootsDir} {
+		if lock != nil {
+			lock.Close()
+		}
+	}
+	ls.stackerDir = nil
+	ls.rootsDir = nil
+}
+
+func lock(config types.StackerConfig) (*StackerLocks, error) {
+	ls := &StackerLocks{}
+
+	var err error
+	ls.stackerDir, err = acquireLock(path.Join(config.StackerDir, lockPath))
+	if err != nil {
+		return nil, err
+	}
+
+	ls.rootsDir, err = acquireLock(path.Join(config.RootFSDir, lockPath))
+	if err != nil {
+		ls.Unlock()
+		return nil, err
+	}
+
+	return ls, nil
+}

--- a/publisher.go
+++ b/publisher.go
@@ -65,11 +65,12 @@ func (p *Publisher) Publish(file string) error {
 	}
 	defer oci.Close()
 
-	s, err := NewStorage(opts.Config)
+	s, locks, err := NewStorage(opts.Config)
 	if err != nil {
 		return err
 	}
 	defer s.Detach()
+	defer locks.Unlock()
 
 	buildCache, err := OpenCache(opts.Config, oci, p.stackerfiles)
 	if err != nil {

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -16,6 +16,7 @@ function teardown() {
     mkdir -p parent
     mount -o loop,user_subvol_rm_allowed btrfs.loop parent
     mkdir -p parent/roots
+    chmod -R 777 parent/roots
 
     stacker --stacker-dir .otherstacker --roots-dir=parent/roots clean
 }

--- a/test/env.bats
+++ b/test/env.bats
@@ -27,3 +27,35 @@ test:
 EOF
     stacker build
 }
+
+@test "two stackers can't run at the same time" {
+    cat > stacker.yaml <<EOF
+test:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    run: |
+        echo hello world
+EOF
+    mkdir -p roots .stacker
+    touch roots/.lock .stacker/.lock
+    chmod 777 -R roots .stacker
+
+    # this only works in overlay, since the btrfs storage will mount
+    # btrfs.loop and the roots/.lock won't be on the same fs. since the kernel
+    # will give us an EBUSY for mounting the same source to the same target
+    # anyway, that can't race, so it's fine to ignore.
+    if [ "$STORAGE_TYPE" == "overlay" ]; then
+        (
+            flock 9
+            bad_stacker build
+            echo "${output}" | grep "couldn't acquire lock"
+        ) 9<roots/.lock
+    fi
+
+    (
+        flock 9
+        bad_stacker build
+        echo "${output}" | grep "couldn't acquire lock"
+    ) 9<.stacker/.lock
+}


### PR DESCRIPTION
stacker is not threadsafe (process-safe?), so let's lock use some advisory
locking to avoid running two stackers at the same time. This results in
error messages like:

error: resource temporarily unavailable
couldn't acquire lock on /home/user/packages/stacker/stackertest-test_two_stackers_can-27t_run_at_the_same_time.n97E26/roots/.lock: lock owned by pid 350804

Note that we are extra paranoid here: we lock both the stacker dir, and the
roots dir, in case someone has diverged in their usage. This suggests maybe
we should just get rid of --roots-dir at some point in the future.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>