### PR TITLE
mksquashfs should use zstd when available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
             - name: install dependencies
               run: |
                   sudo apt-get update
-                  sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev libseccomp-dev libpam-dev bats parallel
+                  sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev libseccomp-dev libpam-dev bats parallel libzstd-dev
                   GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
                   sudo cp ~/go/bin/umoci /usr/bin
                   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0

--- a/doc/install.md
+++ b/doc/install.md
@@ -31,7 +31,7 @@ https://golang.org/doc/install#install
 The other build dependencies can be satisfied with the following command and
 packages:
 
-    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev libpam0g-dev
+    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev libpam0g-dev libzstd-dev
 
 To run `make check` you will also need:
 


### PR DESCRIPTION
Check for presence of zstd support by looking at mksquashfs --help.  On any failures assume that zstd isn't supported, since mqsqaushfs makes it a little difficult to tell if mksquashfs --help succeeded by exiting with status code 1.

Partially addresses: https://github.com/anuvu/stacker/issues/112 tar support has some open questions, so it'll be in another patch.

Open question:  is there a reason to add a command line flag to force using a certain compression algorithm, whether zstd or gzip?