### PR TITLE
ci: drop dead references to storage-type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     build:
         runs-on: ubuntu-20.04
-        name: "golang ${{ matrix.go-version }} storage-type ${{ matrix.storage-type }} privilege ${{ matrix.privilege-level }}"
+        name: "golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
         strategy:
             matrix:
                 go-version: [1.16.x, 1.17.x]


### PR DESCRIPTION
This matrix column was deleted in 5f896b9f3771 ("*: delete the btrfs
storage backend"), but this is leftover. Let's drop it too.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>