### PR TITLE
api: add atomfs mount/umount APIs

### DIFF
--- a/atomfs/molecule.go
+++ b/atomfs/molecule.go
@@ -1,0 +1,226 @@
+package atomfs
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/project-stacker/stacker/mount"
+	"github.com/project-stacker/stacker/squashfs"
+	"golang.org/x/sys/unix"
+)
+
+type Molecule struct {
+	// Atoms is the list of atoms in this Molecule. The first element in
+	// this list is the top most layer in the overlayfs.
+	Atoms []ispec.Descriptor
+
+	config MountOCIOpts
+}
+
+// mountUnderlyingAtoms mounts all the underlying atoms at
+// config.MountedAtomsPath().
+func (m Molecule) mountUnderlyingAtoms() error {
+	for _, a := range m.Atoms {
+		target := m.config.MountedAtomsPath(a.Digest.Encoded())
+
+		mountpoint, err := mount.IsMountpoint(target)
+		if err != nil {
+			return err
+		}
+		if mountpoint {
+			// FIXME: this is unsafe. if someone mounted a
+			// filesystem here, we just use it, without ensuring
+			// the contents match the dm-verity stuff. in the
+			// future, we should:
+			//
+			//   1. go backwards from the mountpoint to the block dev
+			//   2. ask the kernel what its root hash of the block
+			//      dev is, and compare that to the annotation we have
+			//
+			// but for now let's just re-use to get off the ground.
+			continue
+		}
+
+		if err := os.MkdirAll(target, 0755); err != nil {
+			return err
+		}
+
+		rootHash := a.Annotations[squashfs.VerityRootHashAnnotation]
+
+		err = squashfs.Mount(m.config.AtomsPath(a.Digest.Encoded()), target, rootHash)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't mount")
+		}
+	}
+
+	return nil
+}
+
+// overlayArgs returns all of the mount options to pass to the kernel to
+// actually mount this molecule.
+func (m Molecule) overlayArgs(dest string) (string, error) {
+	dirs := []string{}
+	for _, a := range m.Atoms {
+		target := m.config.MountedAtomsPath(a.Digest.Encoded())
+		dirs = append(dirs, target)
+	}
+
+	// overlay doesn't work with one lowerdir. so we do a hack here: we
+	// just create an empty directory called "workaround" in the mounts
+	// directory, and add that to the dir list if it's of length one.
+	if len(dirs) == 1 {
+		workaround := m.config.MountedAtomsPath("workaround")
+		if err := os.MkdirAll(workaround, 0755); err != nil {
+			return "", errors.Wrapf(err, "couldn't make workaround dir")
+		}
+
+		dirs = append(dirs, workaround)
+	}
+
+	// Note that in overlayfs, the first thing is the top most layer in the
+	// overlay.
+	mntOpts := "index=off,lowerdir=" + strings.Join(dirs, ":")
+	return mntOpts, nil
+}
+
+// device mapper has no namespacing. if two different binaries invoke this code
+// (for example, the stacker test suite), we want to be sure we don't both
+// create or delete devices out from the other one when they have detected the
+// device exists. so try to cooperate via this lock.
+const advisoryLockPath = "/dev/shm/atomfs-lock"
+
+func (m Molecule) Mount(dest string) error {
+	lockfile, err := os.Create(advisoryLockPath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer lockfile.Close()
+
+	err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	mntOpts, err := m.overlayArgs(dest)
+	if err != nil {
+		return err
+	}
+
+	// The kernel doesn't allow mount options longer than 4096 chars, so
+	// let's give a nicer error than -EINVAL here.
+	if len(mntOpts) > 4096 {
+		return errors.Errorf("too many lower dirs; must have fewer than 4096 chars")
+	}
+
+	err = m.mountUnderlyingAtoms()
+	if err != nil {
+		return err
+	}
+
+	// now, do the actual overlay mount
+	err = unix.Mount("overlay", dest, "overlay", 0, mntOpts)
+	return errors.Wrapf(err, "couldn't do overlay mount to %s, opts: %s", dest, mntOpts)
+}
+
+func Umount(dest string) error {
+	var err error
+	dest, err = filepath.Abs(dest)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't create abs path for %v", dest)
+	}
+
+	lockfile, err := os.Create(advisoryLockPath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer lockfile.Close()
+
+	err = unix.Flock(int(lockfile.Fd()), unix.LOCK_EX)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	mounts, err := mount.ParseMounts("/proc/self/mountinfo")
+	if err != nil {
+		return err
+	}
+
+	underlyingAtoms := []string{}
+	for _, m := range mounts {
+		if m.FSType != "overlay" {
+			continue
+		}
+
+		if m.Target != dest {
+			continue
+		}
+
+		underlyingAtoms, err = m.GetOverlayDirs()
+		if err != nil {
+			return err
+		}
+		break
+	}
+
+	if len(underlyingAtoms) == 0 {
+		return errors.Errorf("%s is not an atomfs mountpoint", dest)
+	}
+
+	if err := unix.Unmount(dest, 0); err != nil {
+		return err
+	}
+
+	// now, "refcount" the remaining atoms and see if any of ours are
+	// unused
+	usedAtoms := map[string]int{}
+
+	mounts, err = mount.ParseMounts("/proc/self/mountinfo")
+	if err != nil {
+		return err
+	}
+
+	for _, m := range mounts {
+		if m.FSType != "overlay" {
+			continue
+		}
+
+		dirs, err := m.GetOverlayDirs()
+		if err != nil {
+			return err
+		}
+		for _, d := range dirs {
+			usedAtoms[d]++
+		}
+	}
+
+	// If any of the atoms underlying the target mountpoint are now unused,
+	// let's unmount them too.
+	for _, a := range underlyingAtoms {
+		_, used := usedAtoms[a]
+		if used {
+			continue
+		}
+		/* TODO: some kind of logging
+		if !used {
+			log.Warnf("unused atom %s was part of this molecule?")
+			continue
+		}
+		*/
+
+		// the workaround dir isn't really a mountpoint, so don't unmount it
+		if path.Base(a) == "workaround" {
+			continue
+		}
+
+		err = squashfs.Umount(a)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/atomfs/oci.go
+++ b/atomfs/oci.go
@@ -1,0 +1,58 @@
+package atomfs
+
+import (
+	"path"
+
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/umoci"
+	stackeroci "github.com/project-stacker/stacker/oci"
+)
+
+type MountOCIOpts struct {
+	OCIDir       string
+	MetadataPath string
+	Tag          string
+	Target       string
+}
+
+func (c MountOCIOpts) AtomsPath(parts ...string) string {
+	atoms := path.Join(c.OCIDir, "blobs", "sha256")
+	return path.Join(append([]string{atoms}, parts...)...)
+}
+
+func (c MountOCIOpts) MountedAtomsPath(parts ...string) string {
+	mounts := path.Join(c.MetadataPath, "mounts")
+	return path.Join(append([]string{mounts}, parts...)...)
+}
+
+func BuildMoleculeFromOCI(opts MountOCIOpts) (Molecule, error) {
+	oci, err := umoci.OpenLayout(opts.OCIDir)
+	if err != nil {
+		return Molecule{}, err
+	}
+	defer oci.Close()
+
+	man, err := stackeroci.LookupManifest(oci, opts.Tag)
+	if err != nil {
+		return Molecule{}, err
+	}
+
+	atoms := []ispec.Descriptor{}
+	atoms = append(atoms, man.Layers...)
+
+	// The OCI spec says that the first layer should be the bottom most
+	// layer. In overlay it's the top most layer. Since the atomfs codebase
+	// is mostly a wrapper around overlayfs, let's keep things in our db in
+	// the same order that overlay expects them, i.e. the first layer is
+	// the top most. That means we need to reverse the order in which the
+	// atoms were inserted, because they were backwards.
+	//
+	// It's also terrible that golang doesn't have a reverse function, but
+	// that's a discussion for a different block comment.
+	for i := len(atoms)/2 - 1; i >= 0; i-- {
+		opp := len(atoms) - 1 - i
+		atoms[i], atoms[opp] = atoms[opp], atoms[i]
+	}
+
+	return Molecule{Atoms: atoms, config: opts}, nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,19 @@ func stackerResult(err error) {
 	}
 }
 
+func shouldSkipInternalUserns(ctx *cli.Context) bool {
+	args := ctx.Args()
+	if len(args) >= 1 && args[0] == "unpriv-setup" {
+		return true
+	}
+
+	if len(args) >= 2 && args[0] == "internal-go" && args[1] == "atomfs" {
+		return true
+	}
+
+	return false
+}
+
 func main() {
 	sigquits := make(chan os.Signal, 1)
 	go func() {
@@ -265,7 +278,7 @@ func main() {
 		stackerlog.FilterNonStackerLogs(handler, logLevel)
 		stackerlog.Debugf("stacker version %s", version)
 
-		if !ctx.Bool("internal-userns") && len(ctx.Args()) >= 1 && ctx.Args()[0] != "unpriv-setup" {
+		if !ctx.Bool("internal-userns") && !shouldSkipInternalUserns(ctx) {
 			binary, err := os.Readlink("/proc/self/exe")
 			if err != nil {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,13 @@ require (
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker v20.10.11+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.0
+	github.com/freddierice/go-losetup v0.0.0-20210416171645-f09b6c574057
 	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
 	github.com/klauspost/compress v1.14.4 // indirect
 	github.com/klauspost/pgzip v1.2.5
 	github.com/lxc/go-lxc v0.0.0-20210607135324-10de240d43ab
 	github.com/lxc/lxd v0.0.0-20211118162824-0a8d8c489961
-	github.com/martinjungblut/go-cryptsetup v0.0.0-20210812184224-543ba394dcd7
+	github.com/martinjungblut/go-cryptsetup v0.0.0-20220314071908-7b9938e4a08c
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/moby/sys/mountinfo v0.6.0 // indirect
@@ -48,3 +49,5 @@ require (
 replace github.com/containers/image/v5 => github.com/anuvu/image/v5 v5.0.0-20211117201351-4c24aa76235c
 
 replace github.com/opencontainers/umoci => github.com/tych0/umoci v0.4.7-0.20220301172632-87f2e175be31
+
+replace github.com/freddierice/go-losetup => github.com/tych0/go-losetup v0.0.0-20220311175341-5cfd5c59067d

--- a/go.sum
+++ b/go.sum
@@ -1007,8 +1007,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/martinjungblut/go-cryptsetup v0.0.0-20210812184224-543ba394dcd7 h1:/aVXoKeDqXakTTsLbqXWZl1jnyIwuB8njZL/j53p/mc=
-github.com/martinjungblut/go-cryptsetup v0.0.0-20210812184224-543ba394dcd7/go.mod h1:gZoZ0+POlM1ge/VUxWpMmZVNPzzMJ7l436CgkQ5+qzU=
+github.com/martinjungblut/go-cryptsetup v0.0.0-20220314071908-7b9938e4a08c h1:GAbWc5XYdkdSIuiYeLwDNJMtzQYfM2sjqNuZSfEbKOM=
+github.com/martinjungblut/go-cryptsetup v0.0.0-20220314071908-7b9938e4a08c/go.mod h1:gZoZ0+POlM1ge/VUxWpMmZVNPzzMJ7l436CgkQ5+qzU=
 github.com/masterzen/azure-sdk-for-go v3.2.0-beta.0.20161014135628-ee4f0065d00c+incompatible/go.mod h1:mf8fjOu33zCqxUjuiU3I8S1lJMyEAlH+0F2+M5xl3hE=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20161014151040-7a535cd943fc/go.mod h1:CfZSN7zwz5gJiFhZJz49Uzk7mEBHIceWmbFmYx7Hf7E=
@@ -1459,6 +1459,8 @@ github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/twmb/algoimpl v0.0.0-20170717182524-076353e90b94 h1:RVeQNVS7eoXqFemL1LnyzV7yuijHlBtiq6lH5T/mljw=
 github.com/twmb/algoimpl v0.0.0-20170717182524-076353e90b94/go.mod h1:+E0GZE9c8UBk2GYXo9mPIHAtmmBkJlSWCdzLMcsCWV0=
+github.com/tych0/go-losetup v0.0.0-20220311175341-5cfd5c59067d h1:bGbN5QfhOPp79c3cXwwoAWGFXffDl3ZpjjNFxnXcZCA=
+github.com/tych0/go-losetup v0.0.0-20220311175341-5cfd5c59067d/go.mod h1:cdWJrB+PcHXXfp97Gizi9FJNWfNLgO6pt4CgxWpVA5Q=
 github.com/tych0/umoci v0.4.7-0.20220301172632-87f2e175be31 h1:VcR8MhZzaQ76FhqX+qJn3/u6rsd4+HzDtihwh3LdD04=
 github.com/tych0/umoci v0.4.7-0.20220301172632-87f2e175be31/go.mod h1:PcMzafr1xUbR9zxgfDrw31+KYShhTcIAMbOr4cqfPaw=
 github.com/udhos/equalfile v0.3.0 h1:KhG4xhhkittrgIV/ekHtpEPh7MLxtbjm6kLEwp5Dlbg=

--- a/mount/mountinfo.go
+++ b/mount/mountinfo.go
@@ -15,6 +15,22 @@ type Mount struct {
 	Opts   []string
 }
 
+func (m Mount) GetOverlayDirs() ([]string, error) {
+	if m.FSType != "overlay" {
+		return nil, errors.Errorf("%s is not an overlayfs", m.Target)
+	}
+
+	for _, opt := range m.Opts {
+		if !strings.HasPrefix(opt, "lowerdir=") {
+			continue
+		}
+
+		return strings.Split(strings.TrimPrefix(opt, "lowerdir="), ":"), nil
+	}
+
+	return nil, errors.Errorf("no lowerdirs found")
+}
+
 type Mounts []Mount
 
 func (ms Mounts) FindMount(p string) (Mount, bool) {

--- a/squashfs/verity_test.go
+++ b/squashfs/verity_test.go
@@ -37,7 +37,7 @@ func TestVerityMetadata(t *testing.T) {
 	err = ioutil.WriteFile(squashfsFile, content, 0600)
 	assert.NoError(err)
 
-	verityOffset, err := VerityDataLocation(squashfsFile)
+	verityOffset, err := verityDataLocation(squashfsFile)
 	assert.NoError(err)
 
 	// now let's try to verify it at least in userspace. exec cryptsetup

--- a/test/atomfs.bats
+++ b/test/atomfs.bats
@@ -1,0 +1,116 @@
+load helpers
+
+function setup() {
+    stacker_setup
+}
+
+function teardown() {
+    cleanup
+}
+
+function basic_test() {
+    require_privilege priv
+    local verity_arg=$1
+
+    cat > stacker.yaml <<EOF
+test:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    run: |
+        touch /hello
+EOF
+    stacker build --layer-type=squashfs $verity_arg
+    mkdir mountpoint
+    stacker internal-go atomfs mount test-squashfs mountpoint
+
+    [ -f mountpoint/hello ]
+    stacker internal-go atomfs umount mountpoint
+}
+
+@test "--no-squashfs-verity works" {
+    basic_test --no-squashfs-verity
+}
+
+@test "mount + umount works" {
+    basic_test
+
+    # last layer shouldn't exist any more, since it is unique
+    manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    last_layer_num=$(($(cat oci/blobs/sha256/$manifest | jq -r '.layers | length')-1))
+    last_layer_hash=$(cat oci/blobs/sha256/$manifest | jq -r .layers[$last_layer].digest | cut -f2 -d:)
+    [ ! -b "/dev/mapper/$last_layer_hash-verity" ]
+}
+
+@test "mount + umount + mount a tree of images works" {
+    require_privilege priv
+    cat > stacker.yaml <<EOF
+base:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    run: touch /base
+a:
+    from:
+        type: built
+        tag: base
+    run: touch /a
+b:
+    from:
+        type: built
+        tag: base
+    run: touch /b
+c:
+    from:
+        type: built
+        tag: base
+    run: touch /c
+EOF
+    stacker build --layer-type=squashfs
+
+    mkdir a
+    stacker internal-go atomfs mount a-squashfs a
+    [ -f a/a ]
+
+    mkdir b
+    stacker internal-go atomfs mount b-squashfs b
+    [ -f b/b ]
+
+    cat /proc/self/mountinfo
+    echo "mountinfo after b^"
+
+    stacker internal-go atomfs umount b
+
+    # first layer should still exist since a is still mounted
+    manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    first_layer_hash=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
+    [ ! -b "/dev/mapper/$last_layer_hash-verity" ]
+
+    mkdir c
+    stacker internal-go atomfs mount c-squashfs c
+    [ -f c/c ]
+
+    cat /proc/self/mountinfo
+    echo "mountinfo after c^"
+
+    stacker internal-go atomfs umount a
+
+    cat /proc/self/mountinfo
+    echo "mountinfo after umount a^"
+
+    # first layer should still exist since c is still mounted
+    manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    first_layer_hash=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
+    [ ! -b "/dev/mapper/$last_layer_hash-verity" ]
+
+    # c should still be ok
+    [ -f c/c ]
+    [ -f c/sbin/init ]
+    stacker internal-go atomfs umount c
+
+    # c's last layer shouldn't exist any more, since it is unique
+    manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    last_layer_num=$(($(cat oci/blobs/sha256/$manifest | jq -r '.layers | length')-1))
+    last_layer_hash=$(cat oci/blobs/sha256/$manifest | jq -r .layers[$last_layer].digest | cut -f2 -d:)
+    [ ! -b "/dev/mapper/$last_layer_hash-verity" ]
+}


### PR DESCRIPTION
This code is somewhat imported from https://github.com/anuvu/atomfs, with
heavy modification (and some bug fixes) to support the new mount structure
with a verity device in the middle.

The idea here is that the Umount() function should be able to parse the
mountinfo entry and walk back and destroy things as necessary (being
careful not to destroy things that are in use by other atomfs things
entries). This gets kind of tricky because there is no namespace for
devicemapper or the loopback driver and thus the associated devices are
global resources that must be accounted for.

Finally, there are two unsafe FIXMEs introduced in this commit when we
decide to re-use a mountpoint or block dev. In these cases we should ask
the kernel what root hash it has for a block dev, however APIs for this are
still pending, so this patch is "incomplete" for now, but has a sketch of
where the checks would go (and I hope to merge it as-is and continue work
on these APIs).

Additionally, patch necessitated fair amount of new APIs for our
dependences, some of which have been merged upstream and some of which are
still pending, hence the additional replace directives.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>