### PR TITLE
atomfs: verify root hash for existing devices

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
                   GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
                   sudo cp ~/go/bin/umoci /usr/bin
                   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-                  sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev
+                  sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev libdevmapper-dev cryptsetup-bin
                   (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
                   (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
             - run: |

--- a/atomfs/molecule.go
+++ b/atomfs/molecule.go
@@ -29,6 +29,10 @@ func (m Molecule) mountUnderlyingAtoms() error {
 
 		rootHash := a.Annotations[squashfs.VerityRootHashAnnotation]
 
+		if !m.config.AllowMissingVerityData && rootHash == "" {
+			return errors.Errorf("%v is missing verity data", a.Digest)
+		}
+
 		mounts, err := mount.ParseMounts("/proc/self/mountinfo")
 		if err != nil {
 			return err

--- a/atomfs/oci.go
+++ b/atomfs/oci.go
@@ -9,10 +9,11 @@ import (
 )
 
 type MountOCIOpts struct {
-	OCIDir       string
-	MetadataPath string
-	Tag          string
-	Target       string
+	OCIDir                 string
+	MetadataPath           string
+	Tag                    string
+	Target                 string
+	AllowMissingVerityData bool
 }
 
 func (c MountOCIOpts) AtomsPath(parts ...string) string {

--- a/cmd/internal_go.go
+++ b/cmd/internal_go.go
@@ -154,10 +154,11 @@ func doAtomfsMount(ctx *cli.Context) error {
 	}
 
 	opts := atomfs.MountOCIOpts{
-		OCIDir:       config.OCIDir,
-		MetadataPath: path.Join(wd, "atomfs-metadata"),
-		Tag:          tag,
-		Target:       mountpoint,
+		OCIDir:                 config.OCIDir,
+		MetadataPath:           path.Join(wd, "atomfs-metadata"),
+		Tag:                    tag,
+		Target:                 mountpoint,
+		AllowMissingVerityData: true,
 	}
 
 	mol, err := atomfs.BuildMoleculeFromOCI(opts)


### PR DESCRIPTION
Let's get rid of the FIXME's and make re-use of existing devices actually
safe. We can access the existing root-hash through device-mapper directly
(there does not seem to be any way through cryptsetup). Of course, there is
no static-build-able version of libdevmapper bindings anywhere (the only
real bindings are in moby/docker, and they disabled static builds some time
ago). So, let's just write our own tiny bit of cgo for the stuff we want to
extract.

Note that there is already a test case for the happy path: the third test
case in test/atomfs.bats relies on pre-existing verity devices, so we only
add a negative test case here.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>