### PR TITLE
ci/cd: fix ci.yaml to publish built artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,12 @@ jobs:
                   (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
             - run: |
                   make check STORAGE_TYPE=${{ matrix.storage-type }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
+            - if: github.event_name == 'release' && github.event.action == 'published'
+              name: Publish artifacts on releases
+              uses: svenstaro/upload-release-action@v2
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  file: stacker
+                  tag: ${{ github.ref }}
+                  overwrite: true
+                  file_glob: true


### PR DESCRIPTION
Add another step which uploads artifacts when a new release is
published.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>