### PR TITLE
squashfs: rearrange the way we pass ldlibs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ stacker: stacker-dynamic
 		--substitute LXC_BRANCH=$(LXC_BRANCH)
 
 stacker-static: $(GO_SRC) go.mod go.sum cmd/lxc-wrapper/lxc-wrapper
-	$(call build_stacker,static_build,-extldflags '-static -lblkid -luuid -ljson-c -ldevmapper ',stacker)
+	$(call build_stacker,static_build,-extldflags '-static',stacker)
 
 # TODO: because we clean lxc-wrapper in the nested build, this always rebuilds.
 # Could find a better way to do this.

--- a/squashfs/verity_static.go
+++ b/squashfs/verity_static.go
@@ -1,0 +1,10 @@
+//go:build static_build
+// +build static_build
+
+package squashfs
+
+// cryptsetup's pkgconfig is broken (it does not set Requires.private or
+// Libs.private at all), so we do the LDLIBS for it by hand.
+
+// #cgo LDFLAGS: -lcryptsetup -lcrypto -lssl -lblkid -luuid -ljson-c -lpthread -ldl
+import "C"


### PR DESCRIPTION
this way downstream golang projects don't have to know to pass all this
extra nonsense in their builds, they get it for "free".

we do it in this strange way with static_build because newer versions of
cryptsetup (in particular, the latest version, which we're building to
statically link against) depend on json-c, which is not in a lot of repos
(e.g. ubuntu 20.04).

so in order to work around this, we only expose these flags when we
actually need them, when doing a static build.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>