### PR TITLE
ci: add go 1.18 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         name: "golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
         strategy:
             matrix:
-                go-version: [1.16.x, 1.17.x]
+                go-version: [1.17.x, 1.18.x]
                 privilege-level: [priv, unpriv]
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
note that there *is* motivation for keeping golang 1.17 around:
golangci-lint only runs certain linters with golang 1.18 right now,
because generics broke the AST apparently.

So, let's keep 1.17 around and make sure that those linters still run,
since eventually they'll be re-enabled and this way we won't have to go
through and fix everything when they are.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>