### PR TITLE
cmd: stacker with no args shouldn't crash

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -278,7 +278,7 @@ func main() {
 		stackerlog.FilterNonStackerLogs(handler, logLevel)
 		stackerlog.Debugf("stacker version %s", version)
 
-		if !ctx.Bool("internal-userns") && !shouldSkipInternalUserns(ctx) {
+		if !ctx.Bool("internal-userns") && !shouldSkipInternalUserns(ctx) && len(os.Args) > 1 {
 			binary, err := os.Readlink("/proc/self/exe")
 			if err != nil {
 				return err

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -151,3 +151,10 @@ EOF
     umoci unpack --image oci:centos dest
     [ -f dest/rootfs/foo ]
 }
+
+@test "stacker without arguments prints help" {
+    # need to manually call the binary, since our wrapper functions pass
+    # --debug. also, urfave/cli is the one that actually handles this case, and
+    # they exit(0) for now :(
+    "${ROOT_DIR}/stacker" | grep "COMMANDS"
+}


### PR DESCRIPTION
We were getting something like:

panic: runtime error: slice bounds out of range [:2] with capacity 1

goroutine 1 [running]:
main.main.func3(0xc0005ca000)
        /stacker-tree/cmd/main.go:289 +0xb55
github.com/urfave/cli.(*App).Run(0xc0005b4000, {0xc000110200, 0x1, 0x1})
        /stacker-tree/.build/gopath/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:264 +0x56d
main.main()
        /stacker-tree/cmd/main.go:297 +0x120b

derp :)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>