### PR TITLE
storage: drop "using storage backend overlay" message

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -114,7 +114,6 @@ func NewStorage(c types.StackerConfig) (types.Storage, *StackerLocks, error) {
 		return nil, nil, err
 	}
 
-	log.Infof("using storage backend %s", c.StorageType)
 	err = os.MkdirAll(c.StackerDir, 0755)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "couldn't make stacker dir")


### PR DESCRIPTION
We're always using the overlay backend now, since we only have one storage
backend, so let's drop this.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>