### PR TITLE
build: switch the default shell to /usr/bin/sh

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,6 +22,8 @@ import (
 	"github.com/project-stacker/stacker/types"
 )
 
+const DefaultShell = "/usr/bin/sh"
+
 type BuildArgs struct {
 	Config       types.StackerConfig
 	LeaveUnladen bool
@@ -542,7 +544,7 @@ func (b *Builder) BuildMultiple(paths []string) error {
 // container, and writes it to the contianer. It checks that the script already
 // have a shebang? If so, it leaves it as is, otherwise it prepends a shebang.
 func generateShellForRunning(rootfs string, cmd []string, outFile string) error {
-	shebangLine := "#!/bin/sh -xe\n"
+	shebangLine := fmt.Sprintf("#!%s -xe\n", DefaultShell)
 	if strings.HasPrefix(cmd[0], "#!") {
 		shebangLine = ""
 	}

--- a/build.yaml
+++ b/build.yaml
@@ -8,6 +8,7 @@ build-env:
     - https://gitlab.com/cryptsetup/cryptsetup/-/archive/v2.4.3/cryptsetup-v2.4.3.tar.gz
     - https://github.com/lvmteam/lvm2/archive/refs/tags/v2_03_15.tar.gz
   run: |
+    #!/bin/sh
     # libapparmor is only in testing
     head -n1 /etc/apk/repositories | sed 's/main/testing/g' >> /etc/apk/repositories
 
@@ -67,6 +68,7 @@ build:
   binds:
     - . -> /stacker-tree
   run: |
+    #!/bin/sh
     # golang wants somewhere to put its garbage
     export HOME=/root
     export GOPATH=/stacker-tree/.build/gopath

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/project-stacker/stacker"
 	"github.com/project-stacker/stacker/squashfs"
 	"github.com/project-stacker/stacker/types"
@@ -41,7 +43,7 @@ func initCommonBuildFlags() []cli.Flag {
 		},
 		cli.BoolFlag{
 			Name:  "shell-fail",
-			Usage: "exec /bin/sh inside the container if run fails (alias for --on-run-failure=/bin/sh)",
+			Usage: fmt.Sprintf("exec %s inside the container if run fails (alias for --on-run-failure=%s)", stacker.DefaultShell, stacker.DefaultShell),
 		},
 		cli.StringSliceFlag{
 			Name:  "layer-type",

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -27,13 +28,13 @@ var chrootCmd = cli.Command{
 			Usage: "variable substitution in stackerfiles, FOO=bar format",
 		},
 	},
-	ArgsUsage: `[tag] [cmd]
+	ArgsUsage: fmt.Sprintf(`[tag] [cmd]
 
 <tag> is the built tag in the stackerfile to chroot to, or the first tag if
 none is specified.
 
-<cmd> is the command to run, or /bin/sh if none is specified. To specify cmd,
-you must specify a tag.`,
+<cmd> is the command to run, or %s if none is specified. To specify cmd,
+you must specify a tag.`, stacker.DefaultShell),
 }
 
 func doChroot(ctx *cli.Context) error {
@@ -48,7 +49,7 @@ func doChroot(ctx *cli.Context) error {
 		tag = ctx.Args()[0]
 	}
 
-	cmd := "/bin/sh"
+	cmd := stacker.DefaultShell
 
 	if len(ctx.Args()) > 1 {
 		cmd = ctx.Args()[1]

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -5,16 +5,17 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
+	"github.com/project-stacker/stacker"
 	"github.com/urfave/cli"
 )
 
 func validateBuildFailureFlags(ctx *cli.Context) error {
 	if ctx.Bool("shell-fail") {
 		askedFor := ctx.String("on-run-failure")
-		if askedFor != "" && askedFor != "/bin/sh" {
+		if askedFor != "" && askedFor != stacker.DefaultShell {
 			return errors.Errorf("--shell-fail is incompatible with --on-run-failure=%s", askedFor)
 		}
-		err := ctx.Set("on-run-failure", "/bin/sh")
+		err := ctx.Set("on-run-failure", stacker.DefaultShell)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The problem here is as follows:

1. user deletes the /bin -> /usr/bin symlink (e.g. via tar command without
   --keep-directory-symlink or an rsync without --keep-dirlinks)
2. layer is created
3. build on top of that layer fails because /bin doesn't have sh in it any
   more.

Both centos7 and ubuntu have this /bin -> /usr/bin construction, so let's
default to that.

Of course, because everything is wonderful, alpine only ships /bin/sh, and
does not have a /usr/bin -> /bin symlink, so stacker's own build breaks
without explicit shebangs. But best to use what downstream users expect.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>