### PR TITLE
tests: fix git cve fix breakage

### DIFF
--- a/test/basic.bats
+++ b/test/basic.bats
@@ -94,8 +94,8 @@ EOF
 
     publishedGitVersion=$(cat oci/blobs/sha256/$manifest | jq -r '.annotations."com.cisco.stacker.git_version"')
     # ci does not clone tags. There it tests the fallback-to-commit path.
-    myGitVersion=$(git describe --tags) || myGitVersion=$(git rev-parse HEAD)
-    [ -n "$(git status --porcelain --untracked-files=no)" ] &&
+    myGitVersion=$(run_git describe --tags) || myGitVersion=$(run_git rev-parse HEAD)
+    [ -n "$(run_git status --porcelain --untracked-files=no)" ] &&
         dirty="-dirty" || dirty=""
     [ "$publishedGitVersion" = "$myGitVersion$dirty" ]
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,4 +1,8 @@
-ROOT_DIR=$(git rev-parse --show-toplevel)
+function run_git {
+    sudo -u $SUDO_USER git "$@"
+}
+
+ROOT_DIR=$(run_git rev-parse --show-toplevel)
 if [ "$(id -u)" != "0" ]; then
     echo "you should be root to run this suite"
     exit 1


### PR DESCRIPTION
The fix for
https://github.blog/2022-04-12-git-security-vulnerability-announced/ breaks
stacker's test suite, since the directories are owned by a user, but for
the privileged tests git is invoked as root. Let's write a wrapper to
always invoke it as the right user.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>