### PR TITLE
Added logging for changed overlayfs dirs

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -16,11 +16,20 @@ function skip_if_no_unpriv_overlay {
 }
 
 function run_stacker {
+    echo "Debug mode: $NO_DEBUG"
     if [ "$PRIVILEGE_LEVEL" = "priv" ]; then
-        run "${ROOT_DIR}/stacker" --debug "$@"
+        if [[ -n "$NO_DEBUG" && "$NO_DEBUG" = 1 ]]; then
+            run "${ROOT_DIR}/stacker" "$@"
+        else
+            run "${ROOT_DIR}/stacker" --debug "$@"
+        fi
     else
         skip_if_no_unpriv_overlay
-        run sudo -u $SUDO_USER "${ROOT_DIR}/stacker" --debug "$@"
+        if [[ -n "$NO_DEBUG" && "$NO_DEBUG" = 1 ]]; then
+            run sudo -u $SUDO_USER "${ROOT_DIR}/stacker" "$@"
+        else
+            run sudo -u $SUDO_USER "${ROOT_DIR}/stacker" --debug "$@"
+        fi
     fi
 }
 

--- a/test/overlay-dirs.bats
+++ b/test/overlay-dirs.bats
@@ -72,11 +72,11 @@ EOF
 
 @test "overlay_dirs cache works" {
     mkdir dir_to_overlay1
-    touch dir_to_overlay1/file
+    touch dir_to_overlay1/file1.txt
     mkdir dir_to_overlay2
-    touch dir_to_overlay2/file
+    touch dir_to_overlay2/file2.txt
     mkdir dir_to_overlay3
-    touch dir_to_overlay3/file
+    touch dir_to_overlay3/file3.txt
     cat > stacker.yaml << EOF
 first:
     from:
@@ -93,20 +93,27 @@ EOF
     stacker build
     stacker build
     echo $output | grep "found cached layer first"
-    echo "modifying file" > dir_to_overlay1/file
-    echo "modifying file" > dir_to_overlay2/file
-    echo "modifying file" > dir_to_overlay3/file
+    echo "modifying file" > dir_to_overlay1/file1.txt
+    echo "modifying file" > dir_to_overlay2/file2.txt
+    echo "modifying file" > dir_to_overlay3/file3.txt
     NO_DEBUG=1
     stacker build
     echo $output | grep "cache miss because content of 3 overlay dirs changed:"
-    echo $output | grep "and 1 others. use --debug for complete output"
-    echo "modifying file again" > dir_to_overlay1/file
-    echo "modifying file again" > dir_to_overlay2/file
-    echo "modifying file again" > dir_to_overlay3/file
+    echo $output | grep "Changed overlay_dir:"
+    echo $output | grep "dir_to_overlay2"
+    echo $output | grep "file2.txt"
+    echo $output | grep "and 1 other overlay_dirs. use --debug for complete output"
+    # now with debug
+    echo "modifying file again" > dir_to_overlay1/file1.txt
+    echo "modifying file again" > dir_to_overlay2/file2.txt
+    echo "modifying file again" > dir_to_overlay3/file3.txt
     NO_DEBUG=0
     stacker build
     echo $output | grep "cache miss because content of 3 overlay dirs changed:"
-    result=$(echo $output | grep "and 1 others. use --debug for complete output" || echo "empty")
+    echo $output | grep "Changed overlay_dir:"
+    echo $output | grep "dir_to_overlay3"
+    echo $output | grep "file3.txt"
+    result=$(echo $output | grep "and 1 other overlay_dirs. use --debug for complete output" || echo "empty")
     echo $result | grep "empty"
     rm -rf roots
     stacker build

--- a/test/overlay-dirs.bats
+++ b/test/overlay-dirs.bats
@@ -71,25 +71,43 @@ EOF
 }
 
 @test "overlay_dirs cache works" {
-    mkdir dir_to_overlay
-    touch dir_to_overlay/file
+    mkdir dir_to_overlay1
+    touch dir_to_overlay1/file
+    mkdir dir_to_overlay2
+    touch dir_to_overlay2/file
+    mkdir dir_to_overlay3
+    touch dir_to_overlay3/file
     cat > stacker.yaml << EOF
 first:
     from:
         type: oci
         url: $CENTOS_OCI
     overlay_dirs:
-        - source: dir_to_overlay
-          dest: /usr/local
-    run: |
-        [ -f /usr/local/file ]
+        - source: dir_to_overlay1
+          dest: /usr/local1
+        - source: dir_to_overlay2
+          dest: /usr/local2
+        - source: dir_to_overlay3
+          dest: /usr/local3
 EOF
     stacker build
     stacker build
     echo $output | grep "found cached layer first"
-    echo "modifying file" > dir_to_overlay/file
+    echo "modifying file" > dir_to_overlay1/file
+    echo "modifying file" > dir_to_overlay2/file
+    echo "modifying file" > dir_to_overlay3/file
+    NO_DEBUG=1
     stacker build
-    echo $output | grep "cache miss because overlay_dir content changed"
+    echo $output | grep "cache miss because content of 3 overlay dirs changed:"
+    echo $output | grep "and 1 others. use --debug for complete output"
+    echo "modifying file again" > dir_to_overlay1/file
+    echo "modifying file again" > dir_to_overlay2/file
+    echo "modifying file again" > dir_to_overlay3/file
+    NO_DEBUG=0
+    stacker build
+    echo $output | grep "cache miss because content of 3 overlay dirs changed:"
+    result=$(echo $output | grep "and 1 others. use --debug for complete output" || echo "empty")
+    echo $result | grep "empty"
     rm -rf roots
     stacker build
     echo $output | grep "cache miss because overlay_dir was missing"


### PR DESCRIPTION
This PR implements the suggestions from issue #159.
Without --debug, it will print the first 2 changed dirs:
```
cache miss because content of 3 overlay dirs changed:
/home/chofnar/stacker/f2
/home/chofnar/stacker/f3
and 1 others. use --debug for complete output
```

With --debug, it will print all modifications:

```
cache miss because content of 3 overlay dirs changed:
/home/chofnar/stacker/f2
/home/chofnar/stacker/f3
/home/chofnar/stacker/f4
```

Newest change also lists the files that changed:
With --debug
```
cache miss because content of 4 overlay dirs changed:
Changed overlay_dir: /home/piggie/stackeryamls/od1
Contents that changed:
/home/piggie/stackeryamls/od1/subdir/subdirfile.txt
/home/piggie/stackeryamls/od1/file1.txt
Changed overlay_dir: /home/piggie/stackeryamls/od2
Contents that changed:
/home/piggie/stackeryamls/od2/file2.txt
Changed overlay_dir: /home/piggie/stackeryamls/od3
Contents that changed:
/home/piggie/stackeryamls/od3/file3.txt
Changed overlay_dir: /home/piggie/stackeryamls/od4
Contents that changed:
/home/piggie/stackeryamls/od4/file4.txt
```

Without --debug
```
cache miss because content of 4 overlay dirs changed:
Changed overlay_dir: /home/piggie/stackeryamls/od1
Contents that changed:
/home/piggie/stackeryamls/od1/file1.txt
/home/piggie/stackeryamls/od1/subdir/subdirfile.txt
Changed overlay_dir: /home/piggie/stackeryamls/od2
Contents that changed:
/home/piggie/stackeryamls/od2/file2.txt
and 2 other overlay_dirs. use --debug for complete output
```
Signed-off-by: Catalin Hofnar <catalin.hofnar@gmail.com>