### PR TITLE
Avoid too long utsnames

### DIFF
--- a/build.go
+++ b/build.go
@@ -602,7 +602,7 @@ func SetupBuildContainerConfig(config types.StackerConfig, storage types.Storage
 		"lxc.autodev":                   "1",
 		"lxc.pty.max":                   "1024",
 		"lxc.mount.entry":               "none dev/shm tmpfs defaults,create=dir 0 0",
-		"lxc.uts.name":                  name,
+		"lxc.uts.name":                  "stacker",
 		"lxc.net.0.type":                "none",
 		"lxc.environment":               fmt.Sprintf("PATH=%s", container.ReasonableDefaultPath),
 		"lxc.apparmor.allow_incomplete": "1",


### PR DESCRIPTION
When stacker builds a container, it uses the s.TemporaryWritableSnapshot(name)
results.  This can be > 63 chars, which lxc will balk at.  For instance:

error: failed setting config lxc.uts.name to temp-snapshot-build-cluster-api-provider-sveltos-amd64-2544038502: setting config item for the container failed

We don't actually need a good name for the container, it just needs to run.
So just use "stacker".

If we care, we could instead do something only if len(name) > 63...

Signed-off-by: Serge Hallyn <serge@hallyn.com>