### PR TITLE
fix(bind): interpret bind defined as type []map[string]string 

### DIFF
--- a/test/binds.bats
+++ b/test/binds.bats
@@ -1,0 +1,65 @@
+load helpers
+
+function setup() {
+    stacker_setup
+}
+
+function teardown() {
+    cleanup
+}
+
+@test "bind as string slice" {
+    cat > stacker.yaml <<"EOF"
+bind-test:
+    from:
+        type: oci
+        url: ${{CENTOS_OCI}}
+    binds:
+        - ${{bind_path}} -> /root/tree1/foo
+    run: |
+        touch /root/tree1/foo/bar
+EOF
+    mkdir -p tree1/foo
+
+    # since we are creating directory as
+    # real root and then `touch`-ing a file
+    # where in user NS, need to have rw persmission
+    # for others
+    chmod +666 tree1/foo
+
+    bind_path=$(realpath tree1/foo)
+
+    out=$(stacker build --substitute bind_path=${bind_path} --substitute CENTOS_OCI=$CENTOS_OCI)
+
+    [[ "${out}" =~ ^(.*filesystem bind-test built successfully)$ ]]
+
+    stat tree1/foo/bar
+}
+
+@test "bind as struct" {
+    cat > stacker.yaml <<"EOF"
+bind-test:
+    from:
+        type: oci
+        url: ${{CENTOS_OCI}}
+    binds:
+        - Source: ${{bind_path}}
+          Dest: /root/tree1/foo
+    run: |
+        touch /root/tree1/foo/bar
+EOF
+    mkdir -p tree1/foo
+
+    # since we are creating directory as
+    # real root and then `touch`-ing a file
+    # where in user NS, need to have rw persmission
+    # for others
+    chmod +666 tree1/foo
+
+    bind_path=$(realpath tree1/foo)
+
+    out=$(stacker build --substitute bind_path=$bind_path  --substitute CENTOS_OCI=$CENTOS_OCI)
+    [[ "${out}" =~ ^(.*filesystem bind-test built successfully)$ ]]
+
+    stat tree1/foo/bar
+}


### PR DESCRIPTION
As per the type definition of Layer, bind is of type Bind which is a
struct with fields Source and Dest.

But when we do UnmarshalYAML for type Bind, we are assuming that we
would always get the Bind as a []string and not
[]map[interface{}]interface{} (when making a call to
getStringOrStringSlice).

This PR fixes the getStringOrStringSlice to consider Bind defined
as a []map[string]string and returns appropriate bind string
in that case.

Fixes https://github.com/project-stacker/stacker/issues/301