### PR TITLE
pin alpine build tag to 3.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ STACKER_OPTS=--oci-dir=.build/oci --roots-dir=.build/roots --stacker-dir=.build/
 
 build_stacker = go build -tags "$(BUILD_TAGS) $1" -ldflags "-X main.version=$(VERSION_FULL) -X main.lxc_version=$(LXC_VERSION) $2" -o $3 ./cmd
 
-STACKER_BUILD_BASE_IMAGE?=docker://alpine:edge
+STACKER_BUILD_BASE_IMAGE?=docker://alpine:3.16
 LXC_CLONE_URL?=https://github.com/lxc/lxc
 LXC_BRANCH?=stable-4.0
 

--- a/build.yaml
+++ b/build.yaml
@@ -18,9 +18,7 @@ build-env:
       libcap-dev libcap-static \
       libapparmor-dev \
       zlib-static lz4-static \
-      zstd-dev \
-      xz \
-      gettext-dev \
+      zstd-static \
       lvm2-dev util-linux-dev \
       squashfs-tools-ng-dev \
       linux-headers
@@ -59,14 +57,6 @@ build-env:
     cd lxc
     ./autogen.sh
     ./configure --enable-static-binaries --prefix=/usr
-    make -j$(grep -c processor /proc/cpuinfo) install
-    cd /
-
-    # build lzma
-    git clone -b v5.2.6 https://github.com/xz-mirror/xz.git
-    cd xz
-    ./autogen.sh
-    ./configure --enable-static --enable-shared --prefix=/usr
     make -j$(grep -c processor /proc/cpuinfo) install
     cd /
 


### PR DESCRIPTION
alpine:edge has moved forward and some packages have been removed.