### PR TITLE
revert default shell to "/bin/sh"

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ import (
 	"github.com/project-stacker/stacker/types"
 )
 
-const DefaultShell = "/usr/bin/sh"
+const DefaultShell = "/bin/sh"
 
 type BuildArgs struct {
 	Config               types.StackerConfig


### PR DESCRIPTION
revert this part of f4484f8

"/bin/sh" is more likely to be found than "/usr/bin/sh" - Debian for example!

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>