### PR TITLE
Mount overlay with userxattr option

### DIFF
--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -218,7 +218,7 @@ func (o *overlay) GetLXCRootfsConfig(name string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("overlay:%s", lxcRootfsString), nil
+	return fmt.Sprintf("overlay:%s,userxattr", lxcRootfsString), nil
 }
 
 func (o *overlay) TarExtractLocation(name string) string {


### PR DESCRIPTION
This will cause all upperdirs to user user.overlay.* instead of trusted.overlay.* xattrs.  Since a root user may generate a layer which will later be used as a base by an unprivileged build, there's no reason to ever use trusted.*.

Signed-off-by: Serge Hallyn <serge@hallyn.com>