### PR TITLE
check: update stacker check to verify newuidmap

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"io/fs"
 	"os"
+	"os/exec"
 
 	"github.com/pkg/errors"
+	"github.com/pkg/xattr"
 	"github.com/project-stacker/stacker/overlay"
 	"github.com/urfave/cli"
 )
@@ -19,10 +22,56 @@ func doCheck(ctx *cli.Context) error {
 		return errors.Wrapf(err, "couldn't create rootfs dir for testing")
 	}
 
+	if e := verifyNewUIDMap(ctx); e != nil {
+		return e
+	}
+
 	switch config.StorageType {
 	case "overlay":
 		return overlay.Check(config)
 	default:
 		return errors.Errorf("invalid storage type %v", config.StorageType)
 	}
+}
+
+func verifyNewUIDMap(ctx *cli.Context) error {
+	binFile, err := exec.LookPath("newuidmap")
+	if err != nil {
+		return errors.Wrapf(err, "newuidmap not found in path")
+	}
+
+	fileInfo, err := os.Stat(binFile)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't stat file: %s", binFile)
+	}
+
+	if fileInfo.Mode()&0111 == 0 {
+		return errors.Errorf("%s is not executable", binFile)
+	}
+
+	if fileInfo.Mode()&fs.ModeSetuid != 0 {
+		// setuid-root is present, we are good!
+		return nil
+	}
+
+	if e := checkForCap(binFile, "security.capability"); e != nil {
+		return errors.Wrapf(e, "%s does not have either setuid-root or security caps", binFile)
+	}
+
+	return nil
+}
+
+func checkForCap(f string, cap string) error {
+	caps, e := xattr.List(f)
+	if e != nil {
+		return errors.Errorf("could not read caps of %s", f)
+	}
+
+	for _, fcap := range caps {
+		if fcap == cap {
+			return nil
+		}
+	}
+
+	return errors.Errorf("no security cap")
 }


### PR DESCRIPTION
stacker check command now verifies if the newuidmap binary exists in PATH and if the binary is executable with setuid bit on.

Fixes #324

Signed-off-by: Ravi Chamarthy <ravi@chamarthy.dev>