### PR TITLE
Explicitly avoid trying to remove xattrs on symlink

### DIFF
--- a/lib/dir.go
+++ b/lib/dir.go
@@ -7,6 +7,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+func IsSymlink(p string) bool {
+	fi, err := os.Lstat(p)
+	if err != nil {
+		// Some people can't be helped
+		return false
+	}
+
+	return fi.Mode()&os.ModeSymlink != 0
+}
+
 // DirCopy copies a whole directory recursively
 func DirCopy(dest string, source string) error {
 

--- a/overlay/pack.go
+++ b/overlay/pack.go
@@ -352,7 +352,12 @@ func stripOverlayAttrsUnder(dirPath string) error {
 			if err != nil {
 				return err
 			}
-			return stripOverlayAttrs(filepath.Join(dirPath, path))
+			p := filepath.Join(dirPath, path)
+			if lib.IsSymlink(p) {
+				// user.* xattrs "can not" exist on symlinks
+				return nil
+			}
+			return stripOverlayAttrs(p)
 		})
 }
 


### PR DESCRIPTION
You cannot have user.* xattrs on a symlink.

Except...  overlay is in the kernel, it can do what it wants. Unfortunately, fs/xattr.c:xattr_permission() won't allow us to do anything with them:

 124         /*
 125          * In the user.* namespace, only regular files and directories can have
 126          * extended attributes. For sticky directories, only the owner and
 127          * privileged users can write attributes.
 128          */
 129         if (!strncmp(name, XATTR_USER_PREFIX, XATTR_USER_PREFIX_LEN)) {
 130                 if (!S_ISREG(inode->i_mode) && !S_ISDIR(inode->i_mode))
 131                         return (mask & MAY_WRITE) ? -EPERM : -ENODATA;

So just skip trying to remove any xattrs on symlinks.

This *should* be ok, because if I do mksquashfs of a directory with a symlink with user.overlay.origin xattr and then use squashfuse to mount it, the xattr is no longer there.

Signed-off-by: Serge Hallyn <serge@hallyn.com>