### PR TITLE
feat(import): add "copy" support for import

### DIFF
--- a/base.go
+++ b/base.go
@@ -31,6 +31,8 @@ type BaseLayerOpts struct {
 func GetBase(o BaseLayerOpts) error {
 	switch o.Layer.From.Type {
 	case types.BuiltLayer:
+		fallthrough
+	case types.ScratchLayer:
 		return nil
 	case types.TarLayer:
 		cacheDir := path.Join(o.Config.StackerDir, "layer-bases")
@@ -38,7 +40,7 @@ func GetBase(o BaseLayerOpts) error {
 			return err
 		}
 
-		_, err := acquireUrl(o.Config, o.Storage, o.Layer.From.Url, cacheDir, o.Progress, "")
+		_, err := acquireUrl(o.Config, o.Storage, o.Layer.From.Url, cacheDir, o.Progress, "", nil, -1, -1)
 		return err
 	/* now we can do all the containers/image types */
 	case types.OCILayer:
@@ -74,6 +76,8 @@ func SetupRootfs(o BaseLayerOpts) error {
 	}
 
 	switch o.Layer.From.Type {
+	case types.ScratchLayer:
+		return o.Storage.SetupEmptyRootfs(o.Name)
 	case types.TarLayer:
 		err := o.Storage.SetupEmptyRootfs(o.Name)
 		if err != nil {

--- a/build.go
+++ b/build.go
@@ -352,9 +352,11 @@ func (b *Builder) build(s types.Storage, file string) error {
 			return err
 		}
 
-		if err := Import(opts.Config, s, name, l.Imports, opts.Progress); err != nil {
+		if err := Import(opts.Config, s, name, l.Imports, &l.OverlayDirs, opts.Progress); err != nil {
 			return err
 		}
+
+		log.Debugf("overlay-dirs, possibly modified after import: %v", l.OverlayDirs)
 
 		// Need to check if the image has bind mounts, if the image has bind mounts,
 		// it needs to be rebuilt regardless of the build cache

--- a/cache.go
+++ b/cache.go
@@ -207,6 +207,11 @@ func (c *BuildCache) Lookup(name string) (*CacheEntry, bool, error) {
 	}
 
 	for _, imp := range l.Imports {
+		if imp.Dest != "" {
+			// ignore imports which are copied
+			continue
+		}
+
 		cachedImport, ok := result.Imports[imp.Path]
 		if !ok {
 			log.Infof("cache miss because of new import: %s", imp.Path)
@@ -401,6 +406,9 @@ func (c *BuildCache) getBaseHash(name string) (string, error) {
 		}
 
 		return fmt.Sprintf("%d", baseHash), nil
+	case types.ScratchLayer:
+		// no base hash to use
+		return "", nil
 	case types.TarLayer:
 		// use the hash of the input tarball
 		cacheDir := path.Join(c.config.StackerDir, "layer-bases")
@@ -457,6 +465,11 @@ func (c *BuildCache) Put(name string, manifests map[types.LayerType]ispec.Descri
 	}
 
 	for _, imp := range l.Imports {
+		if imp.Dest != "" {
+			// ignore imports which are copied
+			continue
+		}
+
 		fname := path.Base(imp.Path)
 		importsDir := path.Join(c.config.StackerDir, "imports")
 		diskPath := path.Join(importsDir, name, fname)

--- a/cmd/grab.go
+++ b/cmd/grab.go
@@ -43,5 +43,5 @@ func doGrab(ctx *cli.Context) error {
 		return err
 	}
 
-	return stacker.Grab(config, s, name, parts[1], cwd)
+	return stacker.Grab(config, s, name, parts[1], cwd, nil, -1, -1)
 }

--- a/cmd/internal_go.go
+++ b/cmd/internal_go.go
@@ -25,6 +25,14 @@ var internalGoCmd = cli.Command{
 			Action: doCP,
 		},
 		cli.Command{
+			Name:   "chmod",
+			Action: doChmod,
+		},
+		cli.Command{
+			Name:   "chown",
+			Action: doChown,
+		},
+		cli.Command{
 			Name:   "check-aa-profile",
 			Action: doCheckAAProfile,
 		},
@@ -104,6 +112,28 @@ func doCP(ctx *cli.Context) error {
 	}
 
 	return lib.CopyThing(
+		ctx.Args()[0],
+		ctx.Args()[1],
+	)
+}
+
+func doChmod(ctx *cli.Context) error {
+	if len(ctx.Args()) != 2 {
+		return errors.Errorf("wrong number of args")
+	}
+
+	return lib.Chmod(
+		ctx.Args()[0],
+		ctx.Args()[1],
+	)
+}
+
+func doChown(ctx *cli.Context) error {
+	if len(ctx.Args()) != 2 {
+		return errors.Errorf("wrong number of args")
+	}
+
+	return lib.Chown(
 		ctx.Args()[0],
 		ctx.Args()[1],
 	)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func shouldSkipInternalUserns(ctx *cli.Context) bool {
 	}
 
 	if len(args) >= 2 && args[0] == "internal-go" {
-		if args[1] == "atomfs" || args[1] == "cp" {
+		if args[1] == "atomfs" || args[1] == "cp" || args[1] == "chown" || args[1] == "chmod" {
 			return true
 		}
 	}

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -110,6 +110,17 @@ import:
   - /path/to/file
 ```
 
+#### `import dest`
+
+The `import` directive also supports specifying the destination path (specified
+by `dest`) in the resulting container image, where the source file (specified
+by `path`) will be copyied to, for example:
+```
+import:
+  - path: config.json
+    dest: /
+```
+
 ### `overlay_dirs`
 This directive works only with OverlayFS backend storage.
 

--- a/lib/dir.go
+++ b/lib/dir.go
@@ -1,8 +1,11 @@
 package lib
 
 import (
+	"io/fs"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -62,7 +65,7 @@ func DirCopy(dest string, source string) error {
 				return err
 			}
 		} else {
-			if err = FileCopy(dstfp, srcfp); err != nil {
+			if err = FileCopy(dstfp, srcfp, nil, -1, -1); err != nil {
 				return err
 			}
 		}
@@ -80,6 +83,62 @@ func CopyThing(srcpath, destpath string) error {
 	if srcInfo.IsDir() {
 		return DirCopy(destpath, srcpath)
 	} else {
-		return FileCopy(destpath, srcpath)
+		return FileCopy(destpath, srcpath, nil, -1, -1)
 	}
+}
+
+// Chmod changes file permissions
+func Chmod(mode, destpath string) error {
+	destInfo, err := os.Lstat(destpath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if destInfo.IsDir() {
+		return errors.WithStack(os.ErrInvalid)
+	}
+
+	if destInfo.Mode()&os.ModeSymlink != 0 {
+		return errors.WithStack(os.ErrInvalid)
+	}
+
+	// read as an octal value
+	iperms, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return os.Chmod(destpath, fs.FileMode(iperms))
+}
+
+// Chown changes file ownership
+func Chown(owner, destpath string) error {
+	destInfo, err := os.Lstat(destpath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if destInfo.IsDir() {
+		return errors.WithStack(os.ErrInvalid)
+	}
+
+	owns := strings.Split(owner, ":")
+	if len(owns) > 2 {
+		return errors.WithStack(os.ErrInvalid)
+	}
+
+	uid, err := strconv.ParseInt(owns[0], 10, 32)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	gid := int64(-1)
+	if len(owns) > 1 {
+		gid, err = strconv.ParseInt(owns[1], 10, 32)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return os.Lchown(destpath, int(uid), int(gid))
 }

--- a/overlay/overlay-dirs.go
+++ b/overlay/overlay-dirs.go
@@ -61,7 +61,7 @@ func generateOverlayDirLayer(name string, layerType types.LayerType, overlayDir 
 	}
 
 	err = os.Symlink(contents, overlayPath(config, desc.Digest, "overlay"))
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrExist) {
 		return ispec.Descriptor{}, errors.Wrapf(err, "failed to create symlink")
 	}
 


### PR DESCRIPTION
Currently, "import:" directive only allows for temporarily mounting previously layers, and actual copying would have to be done via "run:" directive. But in cases where there is no shell in the current layer, there was no way to achieve this, greatly limiting usability for packaging golang binaries.

Adding support using "dest:" option under "import:" directive.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
