### PR TITLE
feat(build): add a substitute-file option

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -38,6 +38,10 @@ func initCommonBuildFlags() []cli.Flag {
 			Usage: "variable substitution in stackerfiles, FOO=bar format",
 		},
 		cli.StringFlag{
+			Name:  "substitute-file",
+			Usage: "file containing variable substitution in stackerfiles, 'FOO: bar' yaml format",
+		},
+		cli.StringFlag{
 			Name:  "on-run-failure",
 			Usage: "command to run inside container if run fails (useful for inspection)",
 		},
@@ -90,6 +94,7 @@ func newBuildArgs(ctx *cli.Context) (stacker.BuildArgs, error) {
 		Config:               config,
 		NoCache:              ctx.Bool("no-cache"),
 		Substitute:           ctx.StringSlice("substitute"),
+		SubstituteFile:       ctx.String("substitute-file"),
 		OnRunFailure:         ctx.String("on-run-failure"),
 		OrderOnly:            ctx.Bool("order-only"),
 		HashRequired:         ctx.Bool("require-hash"),

--- a/log/log.go
+++ b/log/log.go
@@ -46,6 +46,14 @@ func Infof(msg string, v ...interface{}) {
 	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Infof(msg, v...)
 }
 
+func Errorf(msg string, v ...interface{}) {
+	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Errorf(msg, v...)
+}
+
+func Fatalf(msg string, v ...interface{}) {
+	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Fatalf(msg, v...)
+}
+
 type TextHandler struct {
 	out       io.StringWriter
 	timestamp bool

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -187,4 +187,119 @@ EOF
     bad_stacker build
     [ "$status" -eq 1 ]
     echo $output | grep "forbidden"
-} 
+}
+
+@test "basic workings with substitutions from a file" {
+    cat > subs.yaml << EOF
+    FAVICON: favicon.ico
+EOF
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: tar
+        url: .stacker/layer-bases/centos.tar
+    import:
+        - ./stacker.yaml
+        - https://www.cisco.com/favicon.ico
+        - ./executable
+    run:
+        - cp /stacker/\$FAVICON /\$FAVICON
+        - ls -al /stacker
+        - cp /stacker/executable /usr/bin/executable
+    entrypoint: echo hello world
+    environment:
+        FOO: bar
+    volumes:
+        - /data/db
+    labels:
+        foo: bar
+        bar: baz
+    working_dir: /meshuggah/rocks
+    runtime_user: 1000
+layer1:
+    from:
+        type: built
+        tag: centos
+    run:
+        - rm /favicon.ico
+EOF
+
+    touch executable
+    chmod +x executable
+    mkdir -p .stacker/layer-bases
+    chmod 777 .stacker/layer-bases
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    umoci unpack --image .stacker/layer-bases/oci:centos dest
+    tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
+    rm -rf dest
+
+    stacker build --substitute-file subs.yaml
+    [ "$status" -eq 0 ]
+
+    # did we really download the image to the right place?
+    [ -f .stacker/layer-bases/centos.tar ]
+
+    # did run actually copy the favicon to the right place?
+    stacker grab centos:/favicon.ico
+    [ "$(sha .stacker/imports/centos/favicon.ico)" == "$(sha favicon.ico)" ]
+
+    [ ! -f roots/layer1/rootfs/favicon.ico ] || [ ! -f roots/layer1/overlay/favicon.ico ]
+
+    rm executable
+    stacker grab centos:/usr/bin/executable
+    [ "$(stat --format="%a" executable)" = "755" ]
+
+    # did we do a copy correctly?
+    [ "$(sha .stacker/imports/centos/stacker.yaml)" == "$(sha ./stacker.yaml)" ]
+
+    # check OCI image generation
+    manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    layer=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest)
+    config=$(cat oci/blobs/sha256/$manifest | jq -r .config.digest | cut -f2 -d:)
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Entrypoint | join(" ")')" = "echo hello world" ]
+
+    publishedGitVersion=$(cat oci/blobs/sha256/$manifest | jq -r '.annotations."io.stackeroci.stacker.git_version"')
+    # ci does not clone tags. There it tests the fallback-to-commit path.
+    myGitVersion=$(run_git describe --tags) || myGitVersion=$(run_git rev-parse HEAD)
+    [ -n "$(run_git status --porcelain --untracked-files=no)" ] &&
+        dirty="-dirty" || dirty=""
+    [ "$publishedGitVersion" = "$myGitVersion$dirty" ]
+
+    # need to trim the extra newline from jq
+    cat oci/blobs/sha256/$manifest | jq -r '.annotations."io.stackeroci.stacker.stacker_yaml"' | sed '$ d' > stacker_yaml_annotation
+
+    # now we need to do --substitute FAVICON=favicon.ico
+    sed -e 's/$FAVICON/favicon.ico/g' stacker.yaml > stacker_after_subs
+
+    diff -U5 stacker_yaml_annotation stacker_after_subs
+
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Env[0]')" = "FOO=bar" ]
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.User')" = "1000" ]
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Volumes["/data/db"]')" = "{}" ]
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Labels["foo"]')" = "bar" ]
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Labels["bar"]')" = "baz" ]
+    [ "$(cat oci/blobs/sha256/$config | jq -r '.config.WorkingDir')" = "/meshuggah/rocks" ]
+
+    # TODO: this kind of sucks and is backwards, but now when running as a
+    # privileged container, stacker's code will render $SUDO_USER as the user.
+    # However, when running as an unprivileged user, the re-exec will cause
+    # stacker to think that it is running as root, and render the author as
+    # root. We could/should fix this, but AFAIK nobody pays attention to this
+    # anyway...
+    if [ "$PRIVILEGE_LEVEL" = "priv" ]; then
+        [ "$(cat oci/blobs/sha256/$config | jq -r '.author')" = "$SUDO_USER@$(hostname)" ]
+    else
+        [ "$(cat oci/blobs/sha256/$config | jq -r '.author')" = "root@$(hostname)" ]
+    fi
+    cat oci/blobs/sha256/$config | jq -r '.author'
+
+    manifest2=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    [ "$manifest" = "$manifest2" ]
+    layer2=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest)
+    [ "$layer" = "$layer2" ]
+
+    # let's check that the main tar stuff is understood by umoci
+    umoci unpack --image oci:layer1 dest
+    [ ! -f dest/rootfs/favicon.ico ]
+    [ ! -d dest/rootfs/stacker ]
+}


### PR DESCRIPTION
Currently, all substitution args must be specified on command-line. Sometimes convenient to add them all in a file and read that file.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
