### PR TITLE
Reduce build and test dependency on docker:// urls.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ STACKER_OPTS=--oci-dir=.build/oci --roots-dir=.build/roots --stacker-dir=.build/
 
 build_stacker = go build -tags "$(BUILD_TAGS) $1" -ldflags "-X main.version=$(VERSION_FULL) -X main.lxc_version=$(LXC_VERSION) $2" -o $3 ./cmd
 
-STACKER_BUILD_BASE_IMAGE?=docker://alpine:edge
+STACKER_DOCKER_BASE?=docker://
+STACKER_BUILD_BASE_IMAGE?=$(STACKER_DOCKER_BASE)alpine:edge
+STACKER_BUILD_CENTOS_IMAGE?=$(STACKER_DOCKER_BASE)centos:latest
+STACKER_BUILD_UBUNTU_IMAGE?=$(STACKER_DOCKER_BASE)ubuntu:latest
 LXC_CLONE_URL?=https://github.com/lxc/lxc
 LXC_BRANCH?=stable-5.0
 
@@ -47,7 +50,13 @@ PRIVILEGE_LEVEL?=
 # make check PRIVILEGE_LEVEL=unpriv will run only unprivileged tests
 .PHONY: check
 check: stacker lint
-	sudo -E PATH="$$PATH" LXC_BRANCH="$(LXC_BRANCH)" LXC_CLONE_URL="$(LXC_CLONE_URL)" ./test/main.py \
+	sudo -E PATH="$$PATH" \
+		LXC_BRANCH=$(LXC_BRANCH) \
+		LXC_CLONE_URL=$(LXC_CLONE_URL) \
+		STACKER_BUILD_BASE_IMAGE=$(STACKER_BUILD_BASE_IMAGE) \
+		STACKER_BUILD_CENTOS_IMAGE=$(STACKER_BUILD_CENTOS_IMAGE) \
+		STACKER_BUILD_UBUNTU_IMAGE=$(STACKER_BUILD_UBUNTU_IMAGE) \
+		./test/main.py \
 		$(shell [ -z $(PRIVILEGE_LEVEL) ] || echo --privilege-level=$(PRIVILEGE_LEVEL)) \
 		$(patsubst %,test/%.bats,$(TEST))
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -39,10 +39,13 @@ function image_copy {
     [ "$status" -eq 0 ]
 }
 
+STACKER_DOCKER_BASE=${STACKER_DOCKER_BASE:-docker://}
+STACKER_BUILD_CENTOS_IMAGE=${STACKER_BUILD_CENTOS_IMAGE:-${STACKER_DOCKER_BASE}centos:latest}
+STACKER_BUILD_UBUNTU_IMAGE=${STACKER_BUILD_UBUNTU_IMAGE:-${STACKER_DOCKER_BASE}ubuntu:latest}
 (
     flock 9
-    [ -f "$ROOT_DIR/test/centos/index.json" ] || (image_copy docker://centos:latest "oci:$ROOT_DIR/test/centos:latest" && chmod -R 777 "$ROOT_DIR/test/centos")
-    [ -f "$ROOT_DIR/test/ubuntu/index.json" ] || (image_copy docker://ubuntu:latest "oci:$ROOT_DIR/test/ubuntu:latest" && chmod -R 777 "$ROOT_DIR/test/ubuntu")
+    [ -f "$ROOT_DIR/test/centos/index.json" ] || (image_copy "${STACKER_BUILD_CENTOS_IMAGE}" "oci:$ROOT_DIR/test/centos:latest" && chmod -R 777 "$ROOT_DIR/test/centos")
+    [ -f "$ROOT_DIR/test/ubuntu/index.json" ] || (image_copy "${STACKER_BUILD_UBUNTU_IMAGE}" "oci:$ROOT_DIR/test/ubuntu:latest" && chmod -R 777 "$ROOT_DIR/test/ubuntu")
 ) 9<$ROOT_DIR/test/main.py
 export CENTOS_OCI="$ROOT_DIR/test/centos:latest"
 export UBUNTU_OCI="$ROOT_DIR/test/ubuntu:latest"


### PR DESCRIPTION
Dependance on docker:// urls are painful because of docker quotas. At my large corporation, the docker.io quota is spent most of the time by afternoon.

Currently, stacker build/check depends on docker.io (docker://) urls in these places:
 * build uses docker://alpine:edge - this can already be set via STACKER_BUILD_BASE_IMAGE to some other alpine url.
 * docker://centos:latest - now can be set in STACKER_DOCKER_BASE_CENTOS
 * docker://ubuntu:latest - now can be set in STACKER_DOCKER_BASE_UBUNTU

The change here allows these urls to be configured as a group by setting STACKER_DOCKER_BASE such as one of these:

    make STACKER_DOCKER_BASE=docker://your-local-zot/stacker-deps/
    make STACKER_DOCKER_BASE=oci:/data/sdeps:

or individually like:

    make STACKER_BUILD_BASE_IMAGE=docker://alpine:edge \
      STACKER_BUILD_UBUNTU_IMAGE=oci://data/sdeps:ubuntu:latest

Note: This does not address the issue with depending on "latest" anything, in that the developer of those images can legitimately change their behavior at any point.  Using 'latest' is explicitly opting in for breakage over time.

