### PR TITLE
refactor(bind): improve type validations

### DIFF
--- a/types/layer.go
+++ b/types/layer.go
@@ -52,38 +52,23 @@ type OverlayDir struct {
 
 type OverlayDirs []OverlayDir
 
-func validateDataAsBind(i interface{}) (map[interface{}]interface{}, error) {
-	bindMap, ok := i.(map[interface{}]interface{})
-	if !ok {
-		return nil, errors.Errorf("unable to cast into map[interface{}]interface{}: %T", i)
-	}
-
+func validateDataAsBind(dataMap map[string]string) (map[string]string, error) {
 	// validations
-	bindSource, ok := bindMap["Source"]
+	bindSource, ok := dataMap["Source"]
 	if !ok {
-		return nil, errors.Errorf("bind source missing: %v", i)
+		return nil, errors.Errorf("bind source missing: %v", dataMap)
 	}
 
-	_, ok = bindSource.(string)
+	bindDest, ok := dataMap["Dest"]
 	if !ok {
-		return nil, errors.Errorf("unknown bind source type, expected string: %T", i)
-	}
-
-	bindDest, ok := bindMap["Dest"]
-	if !ok {
-		return nil, errors.Errorf("bind dest missing: %v", i)
-	}
-
-	_, ok = bindDest.(string)
-	if !ok {
-		return nil, errors.Errorf("unknown bind dest type, expected string: %T", i)
+		return nil, errors.Errorf("bind dest missing: %v", dataMap)
 	}
 
 	if bindSource == "" || bindDest == "" {
-		return nil, errors.Errorf("empty source or dest: %v", i)
+		return nil, errors.Errorf("empty source or dest: %v", dataMap)
 	}
 
-	return bindMap, nil
+	return dataMap, nil
 }
 
 func getStringOrStringSlice(data interface{}, xform func(string) ([]string, error)) ([]string, error) {
@@ -104,8 +89,8 @@ func getStringOrStringSlice(data interface{}, xform func(string) ([]string, erro
 			switch v := i.(type) {
 			case string:
 				s = v
-			case interface{}:
-				bindMap, err := validateDataAsBind(i)
+			case map[string]string:
+				bindMap, err := validateDataAsBind(v)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
**What type of PR is this?*
cleanup

**Which issue does this PR fix**:
Not an issue, code cleanup

**What does this PR do / Why do we need it**:
It cleans up the the check for identifying yaml data is of type Bind

**If an issue # is not available please add repro steps and logs showing the issue**: N/A

**Testing done on this change**:
```
$ sudo bats test/binds.bats
[sudo] password for daparikh:
 ✓ bind as string slice
 ✓ bind as struct

2 tests, 0 failures
```

**Automation added to e2e**:

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Darshil Parikh <darshil.parikh@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
