### PR TITLE
refactor(bind): improve type validations

### DIFF
--- a/types/layer.go
+++ b/types/layer.go
@@ -52,38 +52,23 @@ type OverlayDir struct {
 
 type OverlayDirs []OverlayDir
 
-func validateDataAsBind(i interface{}) (map[interface{}]interface{}, error) {
-	bindMap, ok := i.(map[interface{}]interface{})
-	if !ok {
-		return nil, errors.Errorf("unable to cast into map[interface{}]interface{}: %T", i)
-	}
-
+func validateDataAsBind(dataMap map[string]string) error {
 	// validations
-	bindSource, ok := bindMap["Source"]
+	bindSource, ok := dataMap["Source"]
 	if !ok {
-		return nil, errors.Errorf("bind source missing: %v", i)
+		return errors.Errorf("bind source missing: %v", dataMap)
 	}
 
-	_, ok = bindSource.(string)
+	bindDest, ok := dataMap["Dest"]
 	if !ok {
-		return nil, errors.Errorf("unknown bind source type, expected string: %T", i)
-	}
-
-	bindDest, ok := bindMap["Dest"]
-	if !ok {
-		return nil, errors.Errorf("bind dest missing: %v", i)
-	}
-
-	_, ok = bindDest.(string)
-	if !ok {
-		return nil, errors.Errorf("unknown bind dest type, expected string: %T", i)
+		return errors.Errorf("bind dest missing: %v", dataMap)
 	}
 
 	if bindSource == "" || bindDest == "" {
-		return nil, errors.Errorf("empty source or dest: %v", i)
+		return errors.Errorf("empty source or dest: %v", dataMap)
 	}
 
-	return bindMap, nil
+	return nil
 }
 
 func getStringOrStringSlice(data interface{}, xform func(string) ([]string, error)) ([]string, error) {
@@ -104,14 +89,14 @@ func getStringOrStringSlice(data interface{}, xform func(string) ([]string, erro
 			switch v := i.(type) {
 			case string:
 				s = v
-			case interface{}:
-				bindMap, err := validateDataAsBind(i)
+			case map[string]string:
+				err := validateDataAsBind(v)
 				if err != nil {
 					return nil, err
 				}
 
 				// validations passed, return as string in form: source -> dest
-				s = fmt.Sprintf("%s -> %s", bindMap["Source"], bindMap["Dest"])
+				s = fmt.Sprintf("%s -> %s", v["Source"], v["Dest"])
 			default:
 				return nil, errors.Errorf("unknown run array type: %T", i)
 			}


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
Not an issue, code cleanup

**What does this PR do / Why do we need it**:
It cleans up the the check for identifying yaml data is of type Bind

**If an issue # is not available please add repro steps and logs showing the issue**: N/A

**Testing done on this change**:
```
$ sudo bats test/binds.bats
[sudo] password for daparikh:
 ✓ bind as string slice
 ✓ bind as struct

2 tests, 0 failures
```

**Automation added to e2e**: No

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Darshil Parikh <darshil.parikh@gmail.com>