### PR TITLE
ci: fix release pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,16 @@ jobs:
           sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev libdevmapper-dev cryptsetup-bin squashfuse
           (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
           (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
-      - run: |
+      - if: github.event_name != 'release' || github.event.action != 'published'
+        name: Build and test
+        run: |
           make check PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
+        env:
+          REGISTRY_URL: localhost:5000
+      - if: github.event_name == 'release' && github.event.action == 'published'
+        name: Build and test released version
+        run: |
+          make check VERSION=${{ github.event.release.tag_name }}-${{ github.sha }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
         env:
           REGISTRY_URL: localhost:5000
       - uses: actions/cache@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,12 +2,11 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-  schedule:
-    - cron: "0 0 * * 0" # weekly
-  release:
-    types:
-      - published
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: "tagged-release"
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
 
 jobs:
   ci:
@@ -26,9 +26,12 @@ jobs:
         with:
           path: stacker
           key: ${{ github.sha }}
-      - uses: marvinpinto/action-automatic-releases@latest
+      - if: github.event_name == 'release' && github.event.action == 'published'
+        name: Publish artifacts on releases
+        uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
-          files: stacker
-
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: stacker
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO_SRC=$(shell find . -path ./.build -prune -false -o -name \*.go)
-VERSION=$(shell git describe --tags || git rev-parse HEAD)
+VERSION?=$(shell git describe --tags || git rev-parse HEAD)
 VERSION_FULL=$(if $(shell git status --porcelain --untracked-files=no),$(VERSION)-dirty,$(VERSION))
 
 LXC_VERSION?=$(shell pkg-config --modversion lxc)


### PR DESCRIPTION
Disable annotated tagged releases and just rely on GitHub release pipeline.

Disable periodic builds.

Add the release tag in the binary's version.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
