### PR TITLE
feat(run): allow choosing a different shell for `run:`

### DIFF
--- a/cmd/stacker/build.go
+++ b/cmd/stacker/build.go
@@ -71,6 +71,11 @@ func initCommonBuildFlags() []cli.Flag {
 			Usage: "set OCI annotations namespace in the OCI image manifest",
 			Value: "io.stackeroci",
 		},
+		cli.StringFlag{
+			Name:  "shell",
+			Usage: "path to shell to use when invoking the `run:` directive",
+			Value: stacker.DefaultShell,
+		},
 	}
 }
 

--- a/pkg/stacker/build.go
+++ b/pkg/stacker/build.go
@@ -36,6 +36,7 @@ type BuildArgs struct {
 	SetupOnly            bool
 	Progress             bool
 	AnnotationsNamespace string
+	Shell                string
 }
 
 // Builder is responsible for building the layers based on stackerfiles
@@ -126,7 +127,7 @@ func (b *Builder) updateOCIConfigForOutput(sf *types.Stackerfile, s types.Storag
 
 		rootfs := path.Join(opts.Config.RootFSDir, writable, "rootfs")
 		runPath := path.Join(dir, ".stacker-run.sh")
-		err = generateShellForRunning(rootfs, l.GenerateLabels, runPath)
+		err = generateShellForRunning(rootfs, l.GenerateLabels, runPath, opts.Shell)
 		if err != nil {
 			return err
 		}
@@ -454,7 +455,7 @@ func (b *Builder) build(s types.Storage, file string) error {
 		if len(l.Run) != 0 {
 			rootfs := path.Join(opts.Config.RootFSDir, name, "rootfs")
 			shellScript := path.Join(opts.Config.StackerDir, "imports", name, ".stacker-run.sh")
-			err = generateShellForRunning(rootfs, l.Run, shellScript)
+			err = generateShellForRunning(rootfs, l.Run, shellScript, opts.Shell)
 			if err != nil {
 				return err
 			}
@@ -577,8 +578,8 @@ func (b *Builder) BuildMultiple(paths []string) error {
 // generateShellForRunning generates a shell script to run inside the
 // container, and writes it to the contianer. It checks that the script already
 // have a shebang? If so, it leaves it as is, otherwise it prepends a shebang.
-func generateShellForRunning(rootfs string, cmd []string, outFile string) error {
-	shebangLine := fmt.Sprintf("#!%s -xe\n", DefaultShell)
+func generateShellForRunning(rootfs string, cmd []string, outFile string, shell string) error {
+	shebangLine := fmt.Sprintf("#!%s -xe\n", shell)
 	if strings.HasPrefix(cmd[0], "#!") {
 		shebangLine = ""
 	}

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -303,3 +303,15 @@ EOF
     [ ! -f dest/rootfs/favicon.ico ]
     [ ! -d dest/rootfs/stacker ]
 }
+
+@test "build with a non-default shell" {
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    run: |
+      ps axf
+EOF
+    stacker build --shell /usr/bin/bash
+}


### PR DESCRIPTION
Currently, we hardcode to a default shell which may not work for all container images. So add a cmdline arg to override the default.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
