### PR TITLE
feat(publish): add ability to select specific layers to publish

### DIFF
--- a/cmd/stacker/publish.go
+++ b/cmd/stacker/publish.go
@@ -69,6 +69,10 @@ var publishCmd = cli.Command{
 			Usage: "set the output layer type (supported values: tar, squashfs); can be supplied multiple times",
 			Value: &cli.StringSlice{"tar"},
 		},
+		cli.StringSliceFlag{
+			Name:  "layer",
+			Usage: "layer to be published; can be specified multiple times",
+		},
 	},
 	Before: beforePublish,
 }
@@ -120,6 +124,7 @@ func doPublish(ctx *cli.Context) error {
 		Progress:       shouldShowProgress(ctx),
 		SkipTLS:        ctx.Bool("skip-tls"),
 		LayerTypes:     layerTypes,
+		Layers:         ctx.StringSlice("layer"),
 	}
 
 	var stackerFiles []string

--- a/pkg/stacker/publisher.go
+++ b/pkg/stacker/publisher.go
@@ -30,6 +30,7 @@ type PublishArgs struct {
 	Progress       bool
 	SkipTLS        bool
 	LayerTypes     []types.LayerType
+	Layers         []string
 }
 
 // Publisher is responsible for publishing the layers based on stackerfiles
@@ -116,6 +117,19 @@ func (p *Publisher) Publish(file string) error {
 		if l.BuildOnly {
 			log.Infof("will not publish: %s build_only %s", file, name)
 			continue
+		}
+		if len(p.opts.Layers) > 0 {
+			found := false
+			for _, lname := range p.opts.Layers {
+				if lname == name {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				continue
+			}
 		}
 
 		// Verify layer is in build cache

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -116,6 +116,20 @@ function teardown() {
     [ -f dest/layer2_test1/rootfs/root/import1 ]
 }
 
+@test "publish selected multiple layers" {
+    stacker recursive-build -d ocibuilds
+    stacker publish -d ocibuilds --url oci:oci_publish --tag test1 --layer layer1 --layer layer6
+
+     # Unpack published image and check content
+    umoci unpack --image oci_publish:layer1_test1 dest/layer1_test1
+    [ -f dest/layer1_test1/rootfs/root/import1 ]
+    umoci unpack --image oci_publish:layer6_test1 dest/layer6_test1
+    [ -f dest/layer6_test1/rootfs/root/ls_out ]
+    # since we did not publish this layer, shouldn't be found
+    run umoci unpack --image oci_publish:layer2_test1 dest/layer2_test1
+    [ "$status" -ne 0 ]
+}
+
 @test "publish single layer with docker url" {
     stacker build -f ocibuilds/sub1/stacker.yaml
     stacker publish -f ocibuilds/sub1/stacker.yaml --url docker://docker-reg.fake.com/ --username user --password pass --tag test1 --show-only


### PR DESCRIPTION
Currently, publish cmd will push every layer in a stacker.yaml file by default.

This patch adds support to push only required layers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
