### PR TITLE
fix(ci): add a "build-id" input var to ci builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
         description: 'Stringified JSON object listing stacker privilege-level'
+      build-id:
+        required: true
+        type: string
+        description: 'Stringified JSON object listing stacker build-id'
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -22,6 +26,7 @@ jobs:
       matrix:
         go-version: ${{fromJson(inputs.go-version)}}
         privilege-level: ${{fromJson(inputs.privilege-level)}}
+        build-id: ${{fromJson(inputs.build-id)}}
     name: "golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
     steps:
       - uses: actions/checkout@v3
@@ -43,22 +48,14 @@ jobs:
           (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
           (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
           echo "running kernel is: $(uname -a)"
-      - if: github.event_name != 'release' || github.event.action != 'published'
-        name: Build
+      - name: Build
         run: |
-          make stacker
+          make stacker VERSION_FULL=${{ matrix.build-id }}
         env:
           REGISTRY_URL: localhost:5000
-      - if: github.event_name != 'release' || github.event.action != 'published'
-        name: Test
+      - name: Test
         run: |
-          make check PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
-        env:
-          REGISTRY_URL: localhost:5000
-      - if: github.event_name == 'release' && github.event.action == 'published'
-        name: Build and test released version
-        run: |
-          make check VERSION_FULL=${{ github.event.release.tag_name }}-${{ steps.short-sha.outputs.sha }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
+          make check VERSION_FULL=${{ matrix.build-id }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
         env:
           REGISTRY_URL: localhost:5000
       - name: Upload code coverage
@@ -67,4 +64,4 @@ jobs:
         id: restore-build
         with:
           path: stacker
-          key: ${{ steps.short-sha.outputs.sha }}
+          key: ${{ matrix.build-id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,3 +18,5 @@ jobs:
         ["1.20.x"]
       privilege-level: >-
         ["unpriv", "priv"]
+      build-id: >-
+        ["${{ github.sha }}"]

--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -9,28 +9,17 @@ env:
   REGISTRY_URL: localhost:5000
 
 jobs:
-  ci:
-    uses: ./.github/workflows/build.yaml
-    with:
-      # note >-, args needs to be strings to be used as inputs
-      # for the reusable build.yaml workflow
-      go-version: >-
-        ["1.20.x"]
-      privilege-level: >-
-        ["priv"]
   convert:
     name: "convert"
     runs-on: ubuntu-20.04
     # needs ci for the cached stacker binary
     needs: ci
     steps:
-      - uses: benjlevesque/short-sha@v2.1
-        id: short-sha
       - uses: actions/cache@v3
         id: restore-build
         with:
           path: stacker
-          key: ${{ steps.short-sha.outputs.sha }}
+          key: ${{ github.sha }}
       - name: zot registry
         env:
           ZOT_HOST: localhost

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,19 @@ on:
       - published
 
 jobs:
+  build-id:
+    runs-on: ubuntu-latest
+    outputs:
+      build-id: ${{steps.build-id.outputs.build-id}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: benjlevesque/short-sha@v2.1
+        id: short-sha
+      - id: build-id
+        run: echo "build-id=${{ github.event.release.tag_name }}-${{ steps.short-sha.outputs.sha }}" >> "$GITHUB_OUTPUT"
   ci:
     uses: ./.github/workflows/build.yaml
+    needs: build-id
     with:
       # note >-, args needs to be strings to be used as inputs
       # for the reusable build.yaml workflow
@@ -15,19 +26,19 @@ jobs:
         ["1.20.x"]
       privilege-level: >-
         ["priv"]
+      build-id: >-
+        ["${{needs.build-id.outputs.build-id}}"]
   release:
     name: "Tagged Release"
     runs-on: ubuntu-20.04
     # needs ci for the cached stacker binary
-    needs: ci
+    needs: [build-id, ci]
     steps:
-      - uses: benjlevesque/short-sha@v2.1
-        id: short-sha
       - uses: actions/cache@v3
         id: restore-build
         with:
           path: stacker
-          key: ${{ steps.short-sha.outputs.sha }}
+          key: ${{needs.build-id.outputs.build-id}}
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Publish artifacts on releases
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Currently, the github workflows dependencies are chained as follows:

build.yaml -> ci.yaml
release.yaml -> ci.yaml
convert.yaml -> ci.yaml

build.yaml and release.yaml are inline builds but operate on different build triggers. convert.yaml is timer-based and works offline.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
