### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,18 +36,33 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Setup Environment
+        run: |
+          gopath=$PWD/.build/gopath
+          echo "GOPATH=$gopath" >> $GITHUB_ENV
+          echo "GOCACHE=$gopath/gocache" >> $GITHUB_ENV
+          echo "PATH=$gopath/bin:$PATH" >> $GITHUB_ENV
+
+          echo "PWD=$PWD"
+          cat "$GITHUB_ENV"
       - name: install dependencies
         run: |
           sudo add-apt-repository -y ppa:project-machine/squashfuse
           sudo apt-get update
           sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libseccomp-dev libpam-dev bats parallel libzstd-dev
           GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
-          sudo cp ~/go/bin/umoci /usr/bin
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
           sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev libdevmapper-dev cryptsetup-bin squashfuse
           (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
           (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
           echo "running kernel is: $(uname -a)"
+      - name: Go-download
+        run: |
+          make go-download
+      - name: Build-level1
+        run: |
+          make show-info
+          make stacker-dynamic VERSION_FULL=${{ matrix.build-id }}
       - name: Build
         run: |
           make stacker VERSION_FULL=${{ matrix.build-id }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-GO_SRC=$(shell find . -path ./.build -prune -false -o -name \*.go)
+TOP_LEVEL := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+BUILD_D = $(TOP_LEVEL)/.build
+export GOPATH = $(BUILD_D)/gopath
+export GOCACHE = $(GOPATH)/gocache
+
+GO_SRC=$(shell find pkg cmd -name \*.go)
 VERSION?=$(shell git describe --tags || git rev-parse HEAD)
 VERSION_FULL?=$(if $(shell git status --porcelain --untracked-files=no),$(VERSION)-dirty,$(VERSION))
 
@@ -6,7 +11,7 @@ LXC_VERSION?=$(shell pkg-config --modversion lxc)
 
 BUILD_TAGS = exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp osusergo netgo
 
-STACKER_OPTS=--oci-dir=.build/oci --roots-dir=.build/roots --stacker-dir=.build/stacker --storage-type=overlay
+STACKER_OPTS=--oci-dir=$(BUILD_D)/oci --roots-dir=$(BUILD_D)/roots --stacker-dir=$(BUILD_D)/stacker --storage-type=overlay
 
 build_stacker = go build -tags "$(BUILD_TAGS) $1" -ldflags "-X main.version=$(VERSION_FULL) -X main.lxc_version=$(LXC_VERSION) $2" -o $3 ./cmd/stacker
 
@@ -17,31 +22,40 @@ STACKER_BUILD_UBUNTU_IMAGE?=$(STACKER_DOCKER_BASE)ubuntu:latest
 LXC_CLONE_URL?=https://github.com/lxc/lxc
 LXC_BRANCH?=stable-5.0
 
-stacker: stacker-dynamic
-	./stacker-dynamic --debug $(STACKER_OPTS) build \
+STAGE1_STACKER ?= ./stacker-dynamic
+
+STACKER_DEPS = $(GO_SRC) go.mod go.sum
+
+stacker: $(STAGE1_STACKER) $(STACKER_DEPS) cmd/stacker/lxc-wrapper/lxc-wrapper.c
+	$(STAGE1_STACKER) --debug $(STACKER_OPTS) build \
 		-f build.yaml --shell-fail \
 		--substitute STACKER_BUILD_BASE_IMAGE=$(STACKER_BUILD_BASE_IMAGE) \
 		--substitute LXC_CLONE_URL=$(LXC_CLONE_URL) \
 		--substitute LXC_BRANCH=$(LXC_BRANCH) \
 		--substitute VERSION_FULL=$(VERSION_FULL)
 
-stacker-static: $(GO_SRC) go.mod go.sum cmd/stacker/lxc-wrapper/lxc-wrapper
+stacker-static: $(STACKER_DEPS) cmd/stacker/lxc-wrapper/lxc-wrapper
 	$(call build_stacker,static_build,-extldflags '-static',stacker)
 
 # TODO: because we clean lxc-wrapper in the nested build, this always rebuilds.
 # Could find a better way to do this.
-stacker-dynamic: $(GO_SRC) go.mod go.sum cmd/stacker/lxc-wrapper/lxc-wrapper
+stacker-dynamic: $(STACKER_DEPS) cmd/stacker/lxc-wrapper/lxc-wrapper
 	$(call build_stacker,,,stacker-dynamic)
 
 cmd/stacker/lxc-wrapper/lxc-wrapper: cmd/stacker/lxc-wrapper/lxc-wrapper.c
 	make -C cmd/stacker/lxc-wrapper LDFLAGS=-static LDLIBS="$(shell pkg-config --static --libs lxc) -lpthread -ldl" lxc-wrapper
+
+
+.PHONY: go-download
+go-download:
+	go mod download
 
 .PHONY: lint
 lint: cmd/stacker/lxc-wrapper/lxc-wrapper $(GO_SRC)
 	go mod tidy
 	go fmt ./... && ([ -z $(CI) ] || git diff --exit-code)
 	bash test/static-analysis.sh
-	go test -v -trimpath -cover -coverpkg ./... -coverprofile=coverage.txt -covermode=atomic -tags "$(BUILD_TAGS)" ./...
+	go test -v -trimpath -cover -coverpkg stackerbuild.io/stacker/./... -coverprofile=coverage.txt -covermode=atomic -tags "$(BUILD_TAGS)" stackerbuild.io/stacker/./...
 	$(shell go env GOPATH)/bin/golangci-lint run --build-tags "$(BUILD_TAGS)"
 
 TEST?=$(patsubst test/%.bats,%,$(wildcard test/*.bats))
@@ -60,6 +74,11 @@ check: stacker lint
 		./test/main.py \
 		$(shell [ -z $(PRIVILEGE_LEVEL) ] || echo --privilege-level=$(PRIVILEGE_LEVEL)) \
 		$(patsubst %,test/%.bats,$(TEST))
+
+.PHONY:
+show-info:
+	@echo BUILD_D=$(BUILD_D)
+	@go env
 
 .PHONY: vendorup
 vendorup:

--- a/build.yaml
+++ b/build.yaml
@@ -84,9 +84,10 @@ build:
     #!/bin/sh
     # golang wants somewhere to put its garbage
     export HOME=/root
-    export GOPATH=/stacker-tree/.build/gopath
     export LXC_VERSION=$(git -C /lxc rev-parse HEAD)
     export VERSION_FULL=${{VERSION_FULL}}
 
-    make -C /stacker-tree/cmd/stacker/lxc-wrapper clean
-    make -C /stacker-tree stacker-static
+    cd /stacker-tree
+    make show-info
+    make -C cmd/stacker/lxc-wrapper clean
+    make stacker-static


### PR DESCRIPTION
workflow:
 * add Setup Environment section that defines GOPATH and set GOPATH to <checkoutdir>/.build/gopath and GOCACHE to <checkoutdir>/.build/gocache/gocache.

   This means that all 'go' operations in subsequent sections will have that variable set.  The go toolchain will then correctly re-use anything it can throughout the build.

   Note these are the same values that use of Make will set both inside and outside the stacker build.

   (stacker build dir is bind'd into the build environment and Make will set the variable correctly inside also, so the static build will benefit from a cache that the dynamic build did)

 * Separate out 'go mod download' from the build.  This makes better information available on how long operations things took.

   Because GOMODPATH is shared, these will used both by the stacker-dynamic and stacker binary builds.

Makefile:
 * Allow caller to use a already-built "level 1 stacker" to build the current source.  By setting LEVEL1_STACKER as below, you can avoid building (and re-building) the stacker that is used to build the static stacker.

     make LEVEL1_STACKER=/usr/local/bin/stacker

 * export GOPATH and GOCACHE (above)
 * change GO_SRC to only look under pkg/ and cmd/ directories for go source files.  Previously it would search the .build directory which is at best a waste of time and often produced errors to stderr about not being able to read directories.
 * change stacker's dependency from cmd/stacker/lxc-wrapper/lxc-wrapper to cmd/stacker/lxc-wrapper/lxc-wrapper.c .  stacker is built inside the stacker environment and the build.yaml file removes the existing lxc-wrapper, so the internal build will never use lxc-wrapper from the external environment.

At some point we could use the caching in github actions to re-use a .build/gopath directory to get caching across actions.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
