### PR TITLE
Fix link failure by adding zstd-static to the alpine build container.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,7 +18,7 @@ build-env:
       libcap-dev libcap-static \
       libapparmor-dev \
       zlib-static lz4-static \
-      zstd-dev \
+      zstd-dev zstd-static \
       xz \
       gettext-dev \
       lvm2-dev util-linux-dev \


### PR DESCRIPTION
Top commit (54b6501b188041019c19dd6d93c66838bae6c165) on alpine zstd tree commit says:

    main/zstd: split -static

That broke our build as the new zstd-dev does not contain a libzstd.a.

Thankfully the fix is as easy as adding zstd-static to the list of alpine packages in the container.


