### PR TITLE
feat: Add some duration information to test output.

### DIFF
--- a/test/main.py
+++ b/test/main.py
@@ -22,7 +22,7 @@ if options.privilege_level is not None:
     priv_to_test = [options.privilege_level]
 
 for priv in priv_to_test:
-    cmd = ["bats", "--jobs", str(options.jobs), "-t"]
+    cmd = ["bats", "--jobs", str(options.jobs), "--tap", "--timing"]
     cmd.extend(options.tests)
 
     env = os.environ.copy()


### PR DESCRIPTION
The bats test framework provides '--timing' flag that will ammend its "tap" output with test duration information.

Per-test test output is then changed like this:
```
- ok 1 invoking foo with a nonexistent file prints an error
+ ok 1 invoking foo with a nonexistent file prints an error in 1sec
```

Not terribly useful, but better than nothing.

Also here change '-t' to the more readable long form '--tap'.
