### PR TITLE
doc: fix typo in --require-hash and add detail

### DIFF
--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -99,12 +99,20 @@ import:
   - path: stacker://$name/path/to/file
     hash: f805b012017bc769a....
 ```
-Before copying the file it will check if the requested hash matches the actual one.
 
-`stacker build` supports the flag `--require-flag` which checks that all http(s) remote
-imports have an hash in all stacker YAMLs.
+Before copying or downloading the file, it will check if the file's hash matches
+the given value. For file imports, the source file is hashed at build time. For
+HTTP imports, the value returned by the server in the `X-Checksum-Sha256` HTTP
+header is checked first. If that matches, the file is downloaded and then hashed
+and compared again.
 
-This new import mode can be combined with the old one, for example:
+`stacker build` supports the flag `--require-hash`, which will cause a build
+error if any http(s) remote imports do not have a hash specified, in all
+transitively included stacker YAMLs.
+
+If `--require-hash` is not passed, this import mode can be combined with unchecked imports,
+and only files which have the hash specified will be checked.
+
 ```
 import:
   - path: "config.json


### PR DESCRIPTION
--require-flag was a typo

take the opportunity to add some extra detail and be clear about what happens with that flag.

**What type of PR is this?**

This is a documentation PR

**Which issue does this PR fix**:

No issue was filed.

**What does this PR do / Why do we need it**:

fixes an error in the docs

**If an issue # is not available please add repro steps and logs showing the issue**:

see https://stackerbuild.io/v0.40.1/reference/stacker_file/?h=hash#import-hash

**Testing done on this change**:

no testing, yolo

**Automation added to e2e**:

see above re: yolo

**Will this break upgrades or downgrades?**

Let's hope not

**Does this PR introduce any user-facing change?**:

Not during usage.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

👍 
