### PR TITLE
fix(convert): handle conversion of multiple ENV in oneline  in Dockerfile

### DIFF
--- a/test/convert.bats
+++ b/test/convert.bats
@@ -18,6 +18,14 @@ MAINTAINER unknown
 ENV ENV_VERSION1 \$VERSION
 ENV ENV_VERSION2=\$VERSION
 ENV ENV_VERSION3=\$\{VERSION\}
+ENV TEST_PATH="/usr/share/test/bin:$PATH" \
+    TEST_PATHS_CONFIG="/etc/test/test.ini" \
+    TEST_PATHS_DATA="/var/lib/test" \
+    TEST_PATHS_HOME="/usr/share/test" \
+    TEST_PATHS_LOGS="/var/log/test" \
+    TEST_PATHS_PLUGINS="/var/lib/test/plugins" \
+    TEST_PATHS_PROVISIONING="/etc/test/provisioning"
+ENV COMMIT_SHA=${COMMIT_SHA}
 RUN echo \$VERSION
 RUN echo \$\{VERSION\}
 RUN apk add --no-cache lua5.3 lua-filesystem lua-lyaml lua-http


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
Bug

**Which issue does this PR fix**:
```bash
# kind1: ENV needs a default value
ENV foo /bar
# kind2: you can also write
ENV foo=/bar
# kind3: multiple ENV in oneline
ENV TEST_PATH="/usr/share/test/bin:$PATH" \
    TEST_PATHS_CONFIG="/etc/test/test.ini" \
    TEST_PATHS_DATA="/var/lib/test" \
    TEST_PATHS_HOME="/usr/share/test" \
    TEST_PATHS_LOGS="/var/log/test" \
    TEST_PATHS_PLUGINS="/var/lib/test/plugins" \
    TEST_PATHS_PROVISIONING="/etc/test/provisioning"
```

The PR adds support for the 3rd kind

**What does this PR do / Why do we need it**:
For the `stacker convert` to handle Dockerfile with ENV defined in the form:
```
ENV TEST_PATH="/usr/share/test/bin:$PATH" \
    TEST_PATHS_CONFIG="/etc/test/test.ini" \
    TEST_PATHS_DATA="/var/lib/test" \
    TEST_PATHS_HOME="/usr/share/test" \
    TEST_PATHS_LOGS="/var/log/test" \
    TEST_PATHS_PLUGINS="/var/lib/test/plugins" \
    TEST_PATHS_PROVISIONING="/etc/test/provisioning"
```

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
```
 ✓ convert a Dockerfile

1 test, 0 failures
```
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**: enhanced test/convert.bats
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**: No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
