### PR TITLE
Execute inside container through new internal command exec-args.

### DIFF
--- a/cmd/stacker/chroot.go
+++ b/cmd/stacker/chroot.go
@@ -50,10 +50,10 @@ func doChroot(ctx *cli.Context) error {
 		tag = ctx.Args().Get(0)
 	}
 
-	cmd := stacker.DefaultShell
+	cmd := []string{stacker.DefaultShell}
 
 	if ctx.Args().Len() > 1 {
-		cmd = ctx.Args().Get(1)
+		cmd = []string{ctx.Args().Get(1)}
 	}
 
 	file := ctx.String("f")

--- a/cmd/stacker/main.go
+++ b/cmd/stacker/main.go
@@ -71,8 +71,17 @@ func shouldSkipInternalUserns(ctx *cli.Context) bool {
 		return true
 	}
 
+	search := func(needle string, hay ...string) bool {
+		for _, c := range hay {
+			if c == needle {
+				return true
+			}
+		}
+		return false
+	}
+
 	if args.Len() >= 2 && args.Get(0) == "internal-go" {
-		if args.Get(1) == "atomfs" || args.Get(1) == "cp" || args.Get(1) == "chown" || args.Get(1) == "chmod" {
+		if search(args.Get(1), "atomfs", "cp", "chown", "chmod", "exec-args") {
 			return true
 		}
 	}


### PR DESCRIPTION
Stacker executes commands inside a container by setting the lxc config name 'lxc.execute.cmd'.  That is a scalar value but we're ultimately hoping to execute an array.
LXC does support quote escaping in the value, but it does not support nested quotes and other characters could be an issue.

The change here is to add an internal command 'exec-args' and then always utilize that.  exec-args takes a single argument which is expected to be a base64 encoded json string array.

exec-args just decodes the base64 content and then unmarshals a json string array and executes the result.

As an example use:

    $ cat b64blob
    #!/usr/bin/python3
    import json, base64, sys
    print(base64.b64encode(json.dumps(sys.argv[1:]).encode()).decode())

    $ blob=$(./b64blob sh -c \
       'i=0; while i=$((i+1)) && [ $# -ne 0 ]; do \
           printf "%02d: %s$\n" "$i" "$1"; shift; done' \
           -- 'arg one !' "two tooo  " ' -> "thi$;" is three'

    $ ./stacker internal-go exec-args $blob
    01: arg one !$
    02: two tooo  $
    03:  -> "thi$;" is three$

I even validated that an emoji correctly gets through, but didn't want put it in a commit message.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
