### PR TITLE
fix: build.yaml run section needs set -e, and add -x

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -8,7 +8,7 @@ build-env:
     - https://gitlab.com/cryptsetup/cryptsetup/-/archive/v2.6.0/cryptsetup-v2.6.0.tar.gz
     - https://github.com/lvmteam/lvm2/archive/refs/tags/v2_03_18.tar.gz
   run: |
-    #!/bin/sh
+    #!/bin/sh -ex
     # libapparmor is only in testing
     head -n1 /etc/apk/repositories | sed 's/main/testing/g' >> /etc/apk/repositories
 
@@ -23,7 +23,8 @@ build-env:
       gettext-dev \
       lvm2-dev util-linux-dev \
       linux-headers \
-      util-linux-static
+      util-linux-static \
+      po4a
 
     # json-c doesn't have static binaries in alpine
     apk add cmake
@@ -82,7 +83,7 @@ build:
   binds:
     - . -> /stacker-tree
   run: |
-    #!/bin/sh
+    #!/bin/sh -ex
     # golang wants somewhere to put its garbage
     export HOME=/root
     export LXC_VERSION=$(git -C /lxc rev-parse HEAD)


### PR DESCRIPTION
Its been a long time that this has been broken.  The run sections in build.yaml were executing shell scripts without '-e' and thus they would not exit on failure.

The end result was that if something went amuck you had to parse through long error logs for what that was.

Also add '-x' here to make it more obvious where things failed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
