### PR TITLE
Disable test 'can read previous version's cache'

### DIFF
--- a/test/caching.bats
+++ b/test/caching.bats
@@ -185,6 +185,8 @@ EOF
 }
 
 @test "can read previous version's cache" {
+    skip "old does not work as a cache due to stacker/import change in c68147cba8d"
+
     # some additional testing that the cache can be read by older versions of
     # stacker (cache_test.go has the full test for the type, this just checks
     # the mechanics of filepaths and such)


### PR DESCRIPTION
This test is currently broken as a current version of stacker cannot read an old version's cache.  The change was intended, to clean up /stacker under c68147cba8d.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
