### PR TITLE
feat: Support spaces in bom author/vendor and cmd exec inside lxc.

### DIFF
--- a/cmd/stacker/chroot.go
+++ b/cmd/stacker/chroot.go
@@ -50,10 +50,10 @@ func doChroot(ctx *cli.Context) error {
 		tag = ctx.Args().Get(0)
 	}
 
-	cmd := stacker.DefaultShell
+	cmd := []string{stacker.DefaultShell}
 
 	if ctx.Args().Len() > 1 {
-		cmd = ctx.Args().Get(1)
+		cmd[0] = ctx.Args().Get(1)
 	}
 
 	file := ctx.String("f")

--- a/cmd/stacker/lxc-wrapper/lxc-wrapper.c
+++ b/cmd/stacker/lxc-wrapper/lxc-wrapper.c
@@ -21,7 +21,7 @@ struct child_args {
 	int    command_start;
 };
 
-static int spawn_container(char *name, char *lxcpath, char *config)
+static int spawn_container(char *name, char *lxcpath, char *config, char *argv[])
 {
 	struct lxc_container *c;
 
@@ -38,7 +38,7 @@ static int spawn_container(char *name, char *lxcpath, char *config)
 	}
 
 	c->daemonize = false;
-	if (!c->start(c, 1, NULL)) {
+	if (!c->start(c, 1, argv)) {
 		fprintf(stderr, "failed to start container %s\n", name);
 		return -1;
 	}
@@ -253,16 +253,19 @@ int main(int argc, char *argv[])
 	if (!strcmp(argv[1], "spawn")) {
 		int ret, status;
 		char *name, *lxcpath, *config_path;
+		char **args = NULL;
 
-		if (argc != 5) {
+		if (argc < 5) {
 			fprintf(stderr, "bad number of args for spawn: %d\n", argc);
 			return 1;
 		}
 
-
 		name = argv[2];
 		lxcpath = argv[3];
 		config_path = argv[4];
+		if (argc >= 5) {
+			args = &argv[5];
+		}
 
 		ret = isatty(STDIN_FILENO);
 		if (ret < 0) {
@@ -275,7 +278,7 @@ int main(int argc, char *argv[])
 		if (!ret)
 			setsid();
 
-		status = spawn_container(name, lxcpath, config_path);
+		status = spawn_container(name, lxcpath, config_path, args);
 
 		// Try and propagate the container's exit code.
 		if (WIFEXITED(status)) {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -118,11 +118,7 @@ func (c *Container) containerError(theErr error, msg string) error {
 	return errors.Wrapf(theErr, msg)
 }
 
-func (c *Container) Execute(args string, stdin io.Reader) error {
-	if err := c.SetConfig("lxc.execute.cmd", args); err != nil {
-		return err
-	}
-
+func (c *Container) Execute(args []string, stdin io.Reader) error {
 	f, err := os.CreateTemp("", fmt.Sprintf("stacker_%s_run", c.c.Name()))
 	if err != nil {
 		return err
@@ -142,10 +138,7 @@ func (c *Container) Execute(args string, stdin io.Reader) error {
 	cmd, cleanup, err := embed_exec.GetCommand(
 		c.sc.EmbeddedFS,
 		"lxc-wrapper/lxc-wrapper",
-		"spawn",
-		c.c.Name(),
-		c.sc.RootFSDir,
-		f.Name(),
+		append([]string{"spawn", c.c.Name(), c.sc.RootFSDir, f.Name()}, args...)...,
 	)
 	if err != nil {
 		return err

--- a/pkg/stacker/bom.go
+++ b/pkg/stacker/bom.go
@@ -38,16 +38,7 @@ func BuildLayerArtifacts(sc types.StackerConfig, storage types.Storage, l types.
 		return err
 	}
 
-	binary, err := os.Readlink("/proc/self/exe")
-	if err != nil {
-		return err
-	}
-
-	if err := c.BindMount(binary, "/stacker/tools/static-stacker", ""); err != nil {
-		return err
-	}
-
-	cmd := []string{"/stacker/tools/static-stacker"}
+	cmd := []string{insideStaticStacker}
 
 	if sc.Debug {
 		cmd = append(cmd, "--debug")
@@ -92,16 +83,7 @@ func VerifyLayerArtifacts(sc types.StackerConfig, storage types.Storage, l types
 		return err
 	}
 
-	binary, err := os.Readlink("/proc/self/exe")
-	if err != nil {
-		return err
-	}
-
-	if err := c.BindMount(binary, "/stacker/tools/static-stacker", ""); err != nil {
-		return err
-	}
-
-	cmd := []string{"/stacker/tools/static-stacker"}
+	cmd := []string{insideStaticStacker}
 
 	if sc.Debug {
 		cmd = append(cmd, "--debug")

--- a/pkg/stacker/build.go
+++ b/pkg/stacker/build.go
@@ -21,7 +21,10 @@ import (
 	"stackerbuild.io/stacker/pkg/types"
 )
 
-const DefaultShell = "/bin/sh"
+const (
+	DefaultShell        = "/bin/sh"
+	insideStaticStacker = "/stacker/tools/static-stacker"
+)
 
 type BuildArgs struct {
 	Config               types.StackerConfig
@@ -687,6 +690,16 @@ func SetupBuildContainerConfig(config types.StackerConfig, storage types.Storage
 		return err
 	}
 
+	binary, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return err
+	}
+
+	// make stacker binary available inside container
+	if err := c.BindMount(binary, insideStaticStacker, ""); err != nil {
+		return err
+	}
+
 	rootfs, err := storage.GetLXCRootfsConfig(name)
 	if err != nil {
 		return err
@@ -749,19 +762,6 @@ func SetupLayerConfig(config types.StackerConfig, c *container.Container, l type
 		} else {
 			log.Debugf("not bind mounting %s into container", artifactsDir)
 		}
-
-		// make stacker also available to run the internal bom cmds
-		binary, err := os.Readlink("/proc/self/exe")
-		if err != nil {
-			return errors.Wrapf(err, "couldn't find executable for bind mount")
-		}
-
-		err = c.BindMount(binary, "/stacker/tools/static-stacker", "")
-		if err != nil {
-			return err
-		}
-
-		log.Debugf("bind mounting %s into container", binary)
 	}
 
 	for k, v := range env {

--- a/pkg/stacker/build.go
+++ b/pkg/stacker/build.go
@@ -147,7 +147,7 @@ func (b *Builder) updateOCIConfigForOutput(sf *types.Stackerfile, s types.Storag
 			return err
 		}
 
-		err = c.Execute("/stacker/oci-labels/.stacker-run.sh", nil)
+		err = c.Execute([]string{"/stacker/oci-labels/.stacker-run.sh"}, nil)
 		if err != nil {
 			return err
 		}
@@ -476,10 +476,10 @@ func (b *Builder) build(s types.Storage, file string) error {
 			}
 
 			// These should all be non-interactive; let's ensure that.
-			err = c.Execute("/stacker/imports/.stacker-run.sh", nil)
+			err = c.Execute([]string{"/stacker/imports/.stacker-run.sh"}, nil)
 			if err != nil {
 				if opts.OnRunFailure != "" {
-					err2 := c.Execute(opts.OnRunFailure, os.Stdin)
+					err2 := c.Execute([]string{opts.OnRunFailure}, os.Stdin)
 					if err2 != nil {
 						log.Infof("failed executing %s: %s\n", opts.OnRunFailure, err2)
 					}

--- a/pkg/stacker/grab.go
+++ b/pkg/stacker/grab.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/pkg/errors"
 	"stackerbuild.io/stacker/pkg/container"
 	"stackerbuild.io/stacker/pkg/types"
 )
@@ -26,22 +25,12 @@ func Grab(sc types.StackerConfig, storage types.Storage, name string, source str
 	}
 	defer os.Remove(path.Join(sc.RootFSDir, name, "rootfs", "stacker"))
 
-	binary, err := os.Readlink("/proc/self/exe")
-	if err != nil {
-		return errors.Wrapf(err, "couldn't find executable for bind mount")
-	}
-
-	err = c.BindMount(binary, "/stacker/tools/static-stacker", "")
-	if err != nil {
-		return err
-	}
-
 	err = SetupBuildContainerConfig(sc, storage, c, name)
 	if err != nil {
 		return err
 	}
 
-	bcmd := []string{"/stacker/tools/static-stacker", "internal-go"}
+	bcmd := []string{insideStaticStacker, "internal-go"}
 	err = c.Execute(append(bcmd, "cp", source, "/stacker/"+path.Base(source)), nil)
 	if err != nil {
 		return err

--- a/pkg/stacker/grab.go
+++ b/pkg/stacker/grab.go
@@ -41,13 +41,14 @@ func Grab(sc types.StackerConfig, storage types.Storage, name string, source str
 		return err
 	}
 
-	err = c.Execute(fmt.Sprintf("/stacker/tools/static-stacker internal-go cp %s /stacker/%s", source, path.Base(source)), nil)
+	bcmd := []string{"/stacker/tools/static-stacker", "internal-go"}
+	err = c.Execute(append(bcmd, "cp", source, "/stacker/"+path.Base(source)), nil)
 	if err != nil {
 		return err
 	}
 
 	if mode != nil {
-		err = c.Execute(fmt.Sprintf("/stacker/tools/static-stacker internal-go chmod %s /stacker/%s", fmt.Sprintf("%o", *mode), path.Base(source)), nil)
+		err = c.Execute(append(bcmd, "chmod", fmt.Sprintf("%o", *mode), "/stacker/"+path.Base(source)), nil)
 		if err != nil {
 			return err
 		}
@@ -59,7 +60,7 @@ func Grab(sc types.StackerConfig, storage types.Storage, name string, source str
 			owns += fmt.Sprintf(":%d", gid)
 		}
 
-		err = c.Execute(fmt.Sprintf("/stacker/tools/static-stacker internal-go chown %s /stacker/%s", owns, path.Base(source)), nil)
+		err = c.Execute(append(bcmd, "chown", owns, "/stacker/"+path.Base(source)), nil)
 		if err != nil {
 			return err
 		}

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -103,8 +103,8 @@ bom-parent:
         /etc/sysconfig/sshd-permitrootlogin /root/anaconda-* /root/original-* /run/nologin \
         /var/lib/rpm/.rpm.lock /etc/.pwd.lock /etc/BUILDTIME
     annotations:
-      org.opencontainers.image.authors: bom-test
-      org.opencontainers.image.vendor: bom-test
+      org.opencontainers.image.authors: "Alice P. Programmer"
+      org.opencontainers.image.vendor: "ACME Widgets & Trinkets Inc."
       org.opencontainers.image.licenses: MIT
 EOF
     stacker build


### PR DESCRIPTION
 * refactor: Bind stacker binary into container in SetupBuildContainerConfig

   Previously there were 3 individual calls to bind stacker into
   tools/static-stacker.  This just changes that to 1 place, so
   after calling SetupBuildContainerConfig you can use stacker inside.
    
 * test: Change bom test to contain spaces

   The bom test case previously had Author of 'bom-test',
   which was not realiastic and was intentional to avoid
   exposing the bug with spaces.

 * fix: Use arrays for execution rather than scalar string.

   This changes the interface for container.Execute to be an
   array of strings rather than a string, and then changes
   the internal lxc-wrapper pass arguments provided to it
   through to the lxc 'start' api call.

   It ultimately allows us to safely call programs with spaces,
   quotes or other "odd" characters without first serializing
   them in go and relying on lxc start api call to unserialize
   them properly.  lxc.start would ultimately end up just
   split the lxc.execute.cmd on spaces.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
