### PR TITLE
test: Mark the bom tests as slow.

### DIFF
--- a/test/bom.bats
+++ b/test/bom.bats
@@ -9,6 +9,7 @@ function teardown() {
 }
 
 @test "all container contents must be accounted for" {
+  skip_slow_test
   cat > stacker.yaml <<EOF
 bom-parent:
     from:
@@ -66,6 +67,7 @@ EOF
 }
 
 @test "bom tool should work inside run" {
+  skip_slow_test
   cat > stacker.yaml <<EOF
 bom-parent:
     from:

--- a/test/convert.bats
+++ b/test/convert.bats
@@ -48,9 +48,7 @@ EOF
 }
 
 @test "alpine" {
-  if [ -z "${SLOW_TEST}" ]; then
-    skip "test since slow tests are not enabled"
-  fi
+  skip_slow_test
   git clone https://github.com/alpinelinux/docker-alpine.git
   chmod -R a+rwx docker-alpine
   cd docker-alpine
@@ -65,9 +63,7 @@ EOF
 }
 
 @test "elasticsearch" {
-  if [ -z "${SLOW_TEST}" ]; then
-    skip "test since slow tests are not enabled"
-  fi
+  skip_slow_test
   git clone https://github.com/elastic/dockerfiles.git
   chmod -R a+rwx dockerfiles
   cd dockerfiles/elasticsearch
@@ -81,9 +77,7 @@ EOF
 }
 
 @test "python" {
-  if [ -z "${SLOW_TEST}" ]; then
-    skip "test since slow tests are not enabled"
-  fi
+  skip_slow_test
   git clone https://github.com/docker-library/python.git
   cd python/3.11/alpine3.17
   chmod -R a+rw .

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -96,6 +96,16 @@ function require_privilege {
     [ "$PRIVILEGE_LEVEL" = "$1" ] || skip "test not valid for privilege level $PRIVILEGE_LEVEL"
 }
 
+function skip_slow_test {
+    case "${SLOW_TEST:-false}" in
+        true) return;;
+        false) skip "${BATS_TEST_NAME} is slow. Set SLOW_TEST=true to run.";;
+        *) stderr "SLOW_TEST variable must be 'true' or 'false'" \
+            "found '${SLOW_TEST}'"
+           return 1;;
+    esac
+}
+
 function tmpd() {
     mktemp -d "${PWD}/stackertest${1:+-$1}.XXXXXX"
 }


### PR DESCRIPTION
These tests are extremely slow.  We should probably use a different container to test them in.  A recent run of c-i showed:

    ok 19 all container contents must be accounted for in 2617sec
    ok 20 bom tool should work inside run in 1233sec

So these 2 tests accounted for 3850 seconds (64 minutes).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
