### PR TITLE
Avoid mount problems as a result of lxc rootfs values > 4096 chars.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,10 @@ jobs:
           make check VERSION_FULL=${{ matrix.build-id }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
         env:
           REGISTRY_URL: localhost:5000
+      - name: show dmesg
+        if: always()
+        run: |
+          sudo dmesg
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
We had a complaint from a jenkins user where stacker would error like:

    confile_utils - confile_utils.c:set_config_string_item_max:647 -
    Filename too long - overlayfs:....

The problem was taht the lxc.rootfs.path was growing beyond 4096 characters.

To further avoid that problem, add a layer of indirection to the pkg/container/Container type's writing of the lxc.rootfs.path configuration value.

Now, the container has a 'workdir' that is a temp dir. It is hopefully a reasonably short path, and will normally get something like /tmp/c789283801/ (len 16).

shortenRootfs creates symlinks in workdir named '00', '01'...

    <workdir>/00 -> <stacker-roots>/sha256_.../overlay
    <workdir>/01 -> <stacker-roots>/sha267_.../overlay

so instead of paths with length (len(rootsdir) + 80) you end up with paths of len(workdir) + 2, or workdir + 3 if there are > 99 paths.

The use case where we became aware of this had a stacker rootsdir that was 82 chars long (/home/jenkins/workspace/....) and 47 path elements (layers). Its total length was 7580. If shortened with a 16 char workdir then the end result is 910 chars.
