### PR TITLE
fix: clarify comments in molecule.Mount and lxcRootfsString

### DIFF
--- a/pkg/atomfs/molecule.go
+++ b/pkg/atomfs/molecule.go
@@ -65,8 +65,9 @@ func (m Molecule) mountUnderlyingAtoms() error {
 	return nil
 }
 
-// overlayArgs returns all of the mount options to pass to the kernel to
+// overlayArgs - returns all of the mount options to pass to the kernel to
 // actually mount this molecule.
+// This function assumes read-only. It does not provide upperdir or workdir.
 func (m Molecule) overlayArgs(dest string) (string, error) {
 	dirs := []string{}
 	for _, a := range m.Atoms {
@@ -74,9 +75,10 @@ func (m Molecule) overlayArgs(dest string) (string, error) {
 		dirs = append(dirs, target)
 	}
 
-	// overlay doesn't work with one lowerdir. so we do a hack here: we
-	// just create an empty directory called "workaround" in the mounts
-	// directory, and add that to the dir list if it's of length one.
+	// overlay doesn't work with only one lowerdir and no upperdir.
+	// For consistency in that specific case we add a hack here.
+	// We create an empty directory called "workaround" in the mounts
+	// directory, and add that to lowerdir list.
 	if len(dirs) == 1 {
 		workaround := m.config.MountedAtomsPath("workaround")
 		if err := os.MkdirAll(workaround, 0755); err != nil {

--- a/pkg/overlay/metadata.go
+++ b/pkg/overlay/metadata.go
@@ -138,10 +138,11 @@ func (ovl overlayMetadata) lxcRootfsString(config types.StackerConfig, tag strin
 		lowerdirs = append(lowerdirs, contents)
 	}
 
-	// overlayfs doesn't work with 0 lowerdirs, so we add some
-	// workaround dirs if necessary (if e.g. the source only has
-	// one layer, or it's an empty rootfs with no layers, we still
-	// want an overlay mount to keep things consistent)
+	// lxc.rootfs.path overlay string is of form
+	//  'overlayfs:lowerdir[:lowerdir2:lowerdir3...]:upperdir'
+	// 1 or more lowerdir and 1 upperdir are required.
+	// In the case of an empty rootfs with no layers there would be no
+	// lowerdirs but want an overlay mount to keep things consistent.
 	if len(lowerdirs) == 0 {
 		workaround := path.Join(config.RootFSDir, tag, "workaround")
 		err := os.MkdirAll(workaround, 0755)
@@ -167,6 +168,7 @@ func (ovl overlayMetadata) lxcRootfsString(config types.StackerConfig, tag strin
 
 	overlayArgs.WriteString(":")
 
+	// the upperdir is the final token in an 'overlayfs:' lxc.rootfs.path string
 	overlayArgs.WriteString(path.Join(config.RootFSDir, tag, "overlay"))
 
 	log.Debugf("lxc rootfs overlay arg %s", overlayArgs.String())


### PR DESCRIPTION
fix: clarify comments in molecule.Mount and lxcRootfsString

molecule.overlayArgs provides options for a kernel mount-option string.
Kernel mount options for overlay require *more* than one lowerdir if
there is no upperdir.  molecule.Mount always performs read-only
mounts (thus no upperdir). So molecule.overlayArgs must add
a workaround lowerdir if there is only one.

Separately, lxcRootfsString function returns a string to be supplied to
lxc's lxc.rootfs.path.  lxc.rootfs.path is of the form:
  overlayfs:lowerdir[:lowerdir2:lowerdir3]:upperdir.
It requires 1 or more lowerdirs and an upperdir.
So in lxcRootfsString we need to create a workaround dir only if there
are zero lowerdirs (an empty container).

Signed-off-by: Scott Moser <smoser@brickies.net>

this is a follow-on to https://github.com/project-stacker/stacker/pull/493
