### PR TITLE
fix: Improve bind imports, support lower case 'source' in yaml, add go test

### DIFF
--- a/pkg/types/layer_bind_test.go
+++ b/pkg/types/layer_bind_test.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalBindsYamlAndJSON(t *testing.T) {
+	assert := assert.New(t)
+	tables := []struct {
+		desc     string
+		yblob    string
+		jblob    string
+		expected Binds
+		errstr   string
+	}{
+		{desc: "proper array of source/dest bind allowed",
+			yblob: "- source: src1\n  dest: dest1\n",
+			jblob: `[{"source": "src1", "dest": "dest1"}]`,
+			expected: Binds{
+				Bind{Source: "src1", Dest: "dest1"},
+			}},
+		{desc: "array of bind ascii art",
+			yblob: "- src1 -> dest1\n- src2 -> dest2",
+			jblob: `["src1 -> dest1", "src2 -> dest2"]`,
+			expected: Binds{
+				Bind{Source: "src1", Dest: "dest1"},
+				Bind{Source: "src2", Dest: "dest2"},
+			}},
+		{desc: "example mixed valid ascii art and dict",
+			yblob: "- src1 -> dest1\n- source: src2\n  dest: dest2\n",
+			jblob: `["src1 -> dest1", {"source": "src2", "dest": "dest2"}]`,
+			expected: Binds{
+				Bind{Source: "src1", Dest: "dest1"},
+				Bind{Source: "src2", Dest: "dest2"},
+			}},
+		// golang encoding/json is case insensitive
+		{desc: "capital Source/Dest is not allowed as yaml",
+			yblob:    "- Source: src1\n  Dest: dest1\n",
+			expected: Binds{},
+			errstr:   "xpected 'bind'"},
+		{desc: "source is required",
+			yblob:    "- Dest: dest1\n",
+			jblob:    `[{"Dest": "dest1"}]`,
+			expected: Binds{},
+			errstr:   "xpected 'bind'"},
+		{desc: "must be an array",
+			yblob:    "source: src1\ndest: dest1\n",
+			jblob:    `{"source": "src1", "dest": "dest1"}`,
+			expected: Binds{},
+			errstr:   "unmarshal"},
+	}
+	var err error
+	found := Binds{}
+	for _, t := range tables {
+		err = yaml.Unmarshal([]byte(t.yblob), &found)
+		if t.errstr == "" {
+			if !assert.NoError(err, t.desc) {
+				continue
+			}
+			assert.Equal(t.expected, found)
+		} else {
+			assert.ErrorContains(err, t.errstr, t.desc)
+		}
+	}
+
+	for _, t := range tables {
+		if t.jblob == "" {
+			continue
+		}
+		err = json.Unmarshal([]byte(t.jblob), &found)
+		if t.errstr == "" {
+			if !assert.NoError(err, t.desc) {
+				continue
+			}
+			assert.Equal(t.expected, found)
+		} else {
+			assert.ErrorContains(err, t.errstr, t.desc)
+		}
+	}
+}


### PR DESCRIPTION
Entries stacker.yaml's "binds" are of type Bind.
When imported from yaml, support was present for these three things:
1. ascii art specifying source and dest ("source -> dest")
2. source only ("source")
3. map with 'Source' and 'Dest'.

Support for '3' is dropped, and replaced by map with 'source' and 'dest'.  'Source' and 'Dest' are inconsistent with the rest of stacker.yaml. Note that importing from json still does support capital letter variants as the golang json library is case insensitive.

Improvements to the bind yaml and json support generally rely more heavily on the library to do the lifting.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
