### PR TITLE
chore: Clone images to local oci repo before building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,7 @@ jobs:
           echo "GOCACHE=$gopath/gocache" >> $GITHUB_ENV
           echo "PATH=$gopath/bin:$PATH" >> $GITHUB_ENV
           echo "SLOW_TEST=${{inputs.slow-test}}" >> $GITHUB_ENV
+          echo "STACKER_DOCKER_BASE=oci:$PWD/.build/oci-clone:" >> $GITHUB_ENV
 
           echo "PWD=$PWD"
           cat "$GITHUB_ENV"
@@ -69,6 +70,9 @@ jobs:
           GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
           make download-tools
           echo "running kernel is: $(uname -a)"
+      - name: docker-clone
+        run: |
+          make docker-clone "STACKER_DOCKER_BASE=docker://" CLONE_D="$PWD/.build/oci-clone"
       - name: Go-download
         run: |
           make go-download

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -19,13 +19,11 @@ The Makefile supports setting some variables for quicker development.
    or just to speed up iterative development, you can copy these images to a local
    oci repository or local zot repository and point the Make system at that.
 
-       $ OCI_D=/tmp/my.oci
-       $ for d in alpine:edge centos:latest ubuntu:latest; do
-           skopeo copy docker://$d oci:$OCI_D:$d; done
+       $ make docker-clone STACKER_DOCKER_BASE=docker:// CLONE_D=/tmp/my-oci
 
    And then invoke make like:
 
-       make STACKER_DOCKER_BASE="oci:$OCI_D:"
+       make STACKER_DOCKER_BASE="oci:/tmp/my-oci:"
 
    I have a nightly sync job that copies these to a local zot repo and then I can build with:
 


### PR DESCRIPTION
This adds a make target 'docker-clone' which will copy the required docker images to a local oci dir specified by CLONE_D.

You can then use that oci dir as STACKER_DOCKER_BASE.

So:

    make docker-clone CLONE_D=/tmp/my-oci
    export STACKER_DOCKER_BASE=oci:/tmp/my-oci:
    make ...

