### PR TITLE
build: bind BUILD_D in so you can use a BUILD_D outside of the tree.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOP_LEVEL := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 BUILD_D = $(TOP_LEVEL)/.build
-export GOPATH = $(BUILD_D)/gopath
-export GOCACHE = $(GOPATH)/gocache
+export GOPATH ?= $(BUILD_D)/gopath
+export GOCACHE ?= $(GOPATH)/gocache
 
 GO_SRC=$(shell find pkg cmd -name \*.go)
 VERSION?=$(shell git describe --tags || git rev-parse HEAD)
@@ -44,7 +44,8 @@ STACKER_DEPS = $(GO_SRC) go.mod go.sum
 
 stacker: $(STAGE1_STACKER) $(STACKER_DEPS) cmd/stacker/lxc-wrapper/lxc-wrapper.c
 	$(STAGE1_STACKER) --debug $(STACKER_OPTS) build \
-		-f build.yaml --shell-fail \
+		-f build.yaml \
+		--substitute BUILD_D=$(BUILD_D) \
 		--substitute STACKER_BUILD_BASE_IMAGE=$(STACKER_BUILD_BASE_IMAGE) \
 		--substitute LXC_CLONE_URL=$(LXC_CLONE_URL) \
 		--substitute LXC_BRANCH=$(LXC_BRANCH) \

--- a/build.yaml
+++ b/build.yaml
@@ -82,6 +82,7 @@ build:
     tag: build-env
   binds:
     - . -> /stacker-tree
+    - ${{BUILD_D}} -> /build
   run: |
     #!/bin/sh -ex
     # golang wants somewhere to put its garbage
@@ -90,6 +91,6 @@ build:
     export VERSION_FULL=${{VERSION_FULL}}
 
     cd /stacker-tree
-    make show-info
-    make -C cmd/stacker/lxc-wrapper clean
-    make stacker-static
+    make BUILD_D=/build show-info
+    make BUILD_D=/build -C cmd/stacker/lxc-wrapper clean
+    make BUILD_D=/build stacker-static


### PR DESCRIPTION
This allows:

    make BUILD_D=/tmp/build

Without the change, only a BUILD_D that was under the stacker checkout would work.

Note that in order to take advantage of shared GOCACHE and GOPATH, they must be under BUILD_D (they are by default).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
