### PR TITLE
Fix/build deps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,12 +63,7 @@ jobs:
           cat "$GITHUB_ENV"
       - name: install dependencies
         run: |
-          sudo add-apt-repository -y ppa:project-machine/squashfuse
-          sudo apt-get update
-          sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libseccomp-dev libpam-dev bats parallel libzstd-dev
-          sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev libdevmapper-dev cryptsetup-bin squashfuse
-          GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
-          make download-tools
+          ./install-build-deps.sh
           echo "running kernel is: $(uname -a)"
       - name: docker-clone
         run: |

--- a/doc/install.md
+++ b/doc/install.md
@@ -2,11 +2,11 @@
 
 ### Go Dependency
 
-Stacker requires at least go 1.11.
+Stacker requires at least go 1.20.
 
-#### Ubuntu 20.04
+#### Ubuntu 22.04
 
-On Ubuntu 20.04 you can install Go using the instructions at:
+On Ubuntu 22.04 you can install Go using the instructions at:
 https://github.com/golang/go/wiki/Ubuntu
 
 #### Fedora 31
@@ -26,23 +26,19 @@ https://golang.org/doc/install#install
 
 ### Other Dependencies
 
-#### **Ubuntu 20.04**
-
-The other build dependencies can be satisfied with the following command and
-packages:
-
-    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev build-essential
-    sudo apt install libpam0g-dev libselinux-dev libssl-dev libzstd-dev libcryptsetup-dev libdevmapper-dev
+The other build dependencies can be satisfied by running:
 
 #### **Ubuntu 22.04**
 
-    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev build-essential
-    sudo apt install libpam0g-dev libselinux-dev libssl-dev libzstd-dev libcryptsetup-dev libdevmapper-dev cryptsetup-bin pkg-config
 
+    This script will install the current library and build-time depedencies.
+    Once installed it will prepare the system for build by fetching golang
+    tools, downloading go modules and preparing a mirror of remote OCI images.
+
+
+    sudo ./install-build-deps.sh
 
 **To run `make check` you will also need:**
-
-    sudo apt install bats jq tree curl squashfs-tools
 
 **umoci** - https://github.com/opencontainers/umoci
 
@@ -67,4 +63,4 @@ packages:
 ### Building the Stacker Binary
 
 Finally, once you have the build dependencies, stacker can be built with a
-simple `make`. The stacker binary will be output as `./stacker`.
+simple `make stacker`. The stacker binary will be output as `./stacker`.

--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -o pipefail
+set -o errexit
+
+installdeps_fedora() {
+        sudo dnf install \
+        bats \
+        jq \
+        lxc-devel \
+        libcap-devel \
+        libacl-devel
+    if ! command -v go 2>/dev/null; then
+        sudo dnf install golang
+        go version
+    fi
+}
+
+installdeps_ubuntu() {
+    sudo add-apt-repository -y ppa:project-machine/squashfuse
+    sudo apt -yy install \
+            bats \
+            build-essential \
+            cryptsetup-bin \
+            jq \
+            libacl1-dev \
+            libcap-dev \
+            libcryptsetup-dev \
+            libdevmapper-dev \
+            libpam0g-dev \
+            libseccomp-dev \
+            libselinux1-dev \
+            libssl-dev \
+            libzstd-dev \
+            lxc-dev \
+            lxc-utils \
+            parallel \
+            pkg-config \
+            skopeo \
+            squashfs-tools \
+            squashfuse
+    if ! command -v go 2>/dev/null; then
+        sudo apt -yy install golang-go
+        go version
+    fi
+}
+
+installdeps_golang() {
+    go version
+    GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
+    make download-tools
+    make docker-clone
+    make go-download
+}
+
+. /etc/os-release
+
+# install platform deps
+case $ID_LIKE in
+    debian|ubuntu) installdeps_ubuntu;;
+    redhat|fedora) installdeps_fedora;;
+    *)
+        echo "Unknown os ID_LIKE value $ID_LIKE"
+        exit 1
+        ;;
+esac
+
+# install golang deps
+installdeps_golang || exit 1


### PR DESCRIPTION
doc/install.md is quite out-of-date and does not align with what's happening in .github/workflows/build.yml

Changes
  - Add build-essential (for make and friends)
  - Add skopeo/umoci which are needed during build and test
  - Use Ubuntu's golang PPA (instead of deb or snap); Jammy's golang-go is 1.18 and current go.mod requires 1.20
  - Add in the go module prep and docker clone steps

Now, install.md says to just run:

```
sudo ./install-build-deps.sh
make stacker
```

Note: the Fedora steps are equally out of date; that'll need another PR.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

cleanup and documentation

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Add script to prepare an Ubuntu 22.04 instance to build stacker
Updated docs to reference the script since docs were out of date.


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:

build stacker



**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
