### PR TITLE
docs: make type: oci description match code

### DIFF
--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -55,13 +55,14 @@ Hub.
 
 `tar`: `url` is required, everything else is ignored.
 
-`oci`: `url` is required, of the form `path:tag`. This uses the OCI image at
-`url` (which may be a local path).
+`oci`: `url` is required, and must be a local OCI layout URI of the form `oci:/local/path/image:tag`
 
 `built`: `tag` is required, everything else is ignored. `built` bases this
 layer on a previously specified layer in the stacker file.
 
-`scratch`: which is an empty rootfs and can be used to host statically built binaries.
+`scratch`: the base image is an empty rootfs, and can be used with the `dest` field
+of `import` to generate minimal images, e.g. for statically built binaries.
+
 
 ### `import`
 


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:

the description of the `type: oci` field in `from` did not match what the code requires

**What does this PR do / Why do we need it**:

it fixes the description

**If an issue # is not available please add repro steps and logs showing the issue**:

https://stackerbuild.io/v0.40.1/reference/stacker_file/#from

**Testing done on this change**:

yolo

**Automation added to e2e**:

yolo

**Will this break upgrades or downgrades?**

no

**Does this PR introduce any user-facing change?**:

docs only

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
