### PR TITLE
chore: Simplify the install depends workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,8 +65,27 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:project-machine/squashfuse
           sudo apt-get update
-          sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libseccomp-dev libpam-dev bats parallel libzstd-dev
-          sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools libcryptsetup-dev libdevmapper-dev cryptsetup-bin squashfuse
+          deps=(
+             bats
+             cryptsetup-bin
+             git
+             jq
+             libacl1-dev
+             libcap-dev
+             libcryptsetup-dev
+             libdevmapper-dev
+             libpam-dev
+             libseccomp-dev
+             libsquashfs-dev
+             libzstd-dev
+             lxc-dev
+             lxc-utils
+             make
+             parallel
+             squashfs-tools
+             squashfuse
+          )
+          sudo apt-get install -yy --no-install-recommends "${deps[@]}"
           GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
           make download-tools
           echo "running kernel is: $(uname -a)"


### PR DESCRIPTION
Remove: autoconf autoconf autogen automake binutils libtool Add '--no-install-recommends'

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
