### PR TITLE
fix: handle ancient empty docker layers (#522)

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -46,6 +46,10 @@ func Infof(msg string, v ...interface{}) {
 	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Infof(msg, v...)
 }
 
+func Warnf(msg string, v ...interface{}) {
+	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Warnf(msg, v...)
+}
+
 func Errorf(msg string, v ...interface{}) {
 	addStackerLogSentinel(log.NewEntry(log.Log.(*log.Logger))).Errorf(msg, v...)
 }

--- a/pkg/stacker/base.go
+++ b/pkg/stacker/base.go
@@ -87,7 +87,11 @@ func SetupRootfs(o BaseLayerOpts) error {
 	case types.OCILayer:
 		fallthrough
 	case types.DockerLayer:
-		return setupContainersImageRootfs(o)
+		err := setupContainersImageRootfs(o)
+		if err != nil && errors.Is(err, types.ErrEmptyLayers) {
+			return o.Storage.SetupEmptyRootfs(o.Name)
+		}
+		return err
 	default:
 		return errors.Errorf("unknown layer type: %v", o.Layer.From.Type)
 	}

--- a/pkg/types/layer_type.go
+++ b/pkg/types/layer_type.go
@@ -10,6 +10,8 @@ import (
 	"stackerbuild.io/stacker/pkg/squashfs"
 )
 
+var ErrEmptyLayers = errors.New("empty layers")
+
 type LayerType struct {
 	Type   string
 	Verity squashfs.VerityMetadata
@@ -53,7 +55,7 @@ func NewLayerType(lt string, verity squashfs.VerityMetadata) (LayerType, error) 
 
 func NewLayerTypeManifest(manifest ispec.Manifest) (LayerType, error) {
 	if len(manifest.Layers) == 0 {
-		return LayerType{}, errors.Errorf("no existing layers to determine layer type")
+		return NewLayerType("tar", squashfs.VerityMetadataMissing)
 	}
 
 	switch manifest.Layers[0].MediaType {

--- a/test/empty-layers.bats
+++ b/test/empty-layers.bats
@@ -61,3 +61,28 @@ EOF
 
     [ "$layers0" = "$layers1" ]
 }
+
+@test "an image with empty layers" {
+  umoci init --layout oci
+  umoci new --image oci:emptylayer
+  chmod -R a+rw oci
+
+  cat > stacker.yaml <<EOF
+test_empty_layer:
+    from:
+        type: oci
+        url: oci:emptylayer
+EOF
+    stacker build
+}
+
+@test "a real-world docker image with empty/filler layer" {
+    cat > stacker.yaml <<EOF
+image:
+    from:
+        type: docker
+        url: docker://ghcr.io/project-stacker/grafana-oss:10.1.2-ubuntu
+EOF
+    stacker build
+}
+


### PR DESCRIPTION
Earlier versions of docker images had empty layers of 1024 zero-valued octets.

https://github.com/moby/moby/issues/20917#issuecomment-191901912

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>
(cherry picked from commit f0f964216cb7dc1c5ec529ec49824e9a1879ef45)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
