### PR TITLE
feat: Support legacy 'import' directive and use 'imports' for future

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ build-env:
   from:
     type: docker
     url: ${{STACKER_BUILD_BASE_IMAGE}}
-  import:
+  imports:
     - https://github.com/json-c/json-c/archive/refs/tags/json-c-0.16-20220414.tar.gz
     - https://gitlab.com/cryptsetup/cryptsetup/-/archive/v2.6.0/cryptsetup-v2.6.0.tar.gz
     - https://github.com/lvmteam/lvm2/archive/refs/tags/v2_03_18.tar.gz

--- a/cmd/stacker/bom.go
+++ b/cmd/stacker/bom.go
@@ -10,6 +10,7 @@ import (
 	"stackerbuild.io/stacker-bom/pkg/bom"
 	"stackerbuild.io/stacker-bom/pkg/distro"
 	"stackerbuild.io/stacker-bom/pkg/fs"
+	"stackerbuild.io/stacker/pkg/types"
 )
 
 var bomCmd = cli.Command{
@@ -39,7 +40,7 @@ func doBomDiscover(ctx *cli.Context) error {
 	author := "stacker-internal"
 	org := "stacker-internal"
 
-	if err := fs.Discover(author, org, "/stacker/artifacts/installed-packages.json"); err != nil {
+	if err := fs.Discover(author, org, types.InternalStackerDir+"/artifacts/installed-packages.json"); err != nil {
 		return nil
 	}
 
@@ -57,7 +58,8 @@ func doBomGenerate(ctx *cli.Context) error {
 	org := "stacker-internal"
 	lic := "unknown"
 
-	if err := distro.ParsePackage(input, author, org, lic, fmt.Sprintf("/stacker/artifacts/%s.json", filepath.Base(input))); err != nil {
+	if err := distro.ParsePackage(input, author, org, lic, fmt.Sprintf("%s/artifacts/%s.json",
+		types.InternalStackerDir, filepath.Base(input))); err != nil {
 		return nil
 	}
 
@@ -98,16 +100,17 @@ func doBomVerify(ctx *cli.Context) error {
 	org := ctx.Args().Get(3)
 
 	// first merge all individual sbom artifacts that may have been generated
-	if err := bom.MergeDocuments("/stacker/artifacts", name, author, org, dest); err != nil {
+	iDir := types.InternalStackerDir
+	if err := bom.MergeDocuments(iDir+"/artifacts", name, author, org, dest); err != nil {
 		return err
 	}
 
 	// check against inventory
 	if err := fs.GenerateInventory("/",
-		[]string{"/proc", "/sys", "/dev", "/etc/resolv.conf", "/stacker"},
-		"/stacker/artifacts/inventory.json"); err != nil {
+		[]string{"/proc", "/sys", "/dev", "/etc/resolv.conf", iDir},
+		iDir+"/artifacts/inventory.json"); err != nil {
 		return err
 	}
 
-	return fs.Verify(dest, "/stacker/artifacts/inventory.json", "")
+	return fs.Verify(dest, iDir+"/artifacts/inventory.json", "")
 }

--- a/cmd/stacker/chroot.go
+++ b/cmd/stacker/chroot.go
@@ -98,11 +98,11 @@ func doChroot(ctx *cli.Context) error {
 	}
 	defer c.Close()
 
-	err = stacker.SetupBuildContainerConfig(config, s, c, name)
+	err = stacker.SetupBuildContainerConfig(config, s, c, types.InternalStackerDir, name)
 	if err != nil {
 		return err
 	}
-	err = stacker.SetupLayerConfig(config, c, layer, name)
+	err = stacker.SetupLayerConfig(config, c, layer, types.InternalStackerDir, name)
 	if err != nil {
 		return err
 	}

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -64,10 +64,10 @@ layer on a previously specified layer in the stacker file.
 of `import` to generate minimal images, e.g. for statically built binaries.
 
 
-### `import`
+### `imports`
 
-The `import` directive describes what files should be made available in
-`/stacker` during the `run` phase. There are three forms of importing supported
+The `imports` directive describes what files should be made available in
+`/stacker/imports` during the `run` phase. There are three forms of importing supported
 today:
 
     /path/to/file
@@ -89,10 +89,10 @@ Will grab /path/to/file from the previously built layer `$name`.
 
 #### `import hash`
 
-The `import` directive also supports specifying the hash(sha256sum) of import source,
-for all the three forms presented above, for example:
+Each entry in the `imports' directive also supports specifying the hash(sha256sum) of
+import source, for all the three forms presented above, for example:
 ```
-import:
+imports:
   - path: config.json
     hash: f55af805b012017bc....
   - path: http://example.com/foo.tar.gz
@@ -115,7 +115,7 @@ If `--require-hash` is not passed, this import mode can be combined with uncheck
 and only files which have the hash specified will be checked.
 
 ```
-import:
+imports:
   - path: "config.json
     hash: "BEEFcafeaaaaAAAA...."
   - /path/to/file
@@ -127,10 +127,16 @@ The `import` directive also supports specifying the destination path (specified
 by `dest`) in the resulting container image, where the source file (specified
 by `path`) will be copyied to, for example:
 ```
-import:
+imports:
   - path: config.json
     dest: /
 ```
+
+
+### (Deprecated) `import`
+The deprecated `import` directive works like `imports` except that
+the entries in the `import` array will be placed into `/stacker/` rather
+than `/stacker/imports`.
 
 ### `overlay_dirs`
 This directive works only with OverlayFS backend storage.

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -98,7 +98,7 @@ output will look something like:
 
 There are two new stacker file directives here:
 
-    import:
+    imports:
         - config.json
         - install.sh
 
@@ -115,8 +115,8 @@ And then there is:
 
     run: |
         mkdir -p /etc/myapp
-        cp /stacker/config.json /etc/myapp/
-        /stacker/install.sh
+        cp /stacker/imports/config.json /etc/myapp/
+        /stacker/imports/install.sh
 
 Which is the set of commands to run in order to install and configure the
 image.
@@ -152,8 +152,8 @@ emitted in the final OCI image. For example:
         from:
             type: docker
             url: docker://centos:latest
-        import: stacker://build/umoci.static
-        run: cp /stacker/umoci.static /usr/bin/umoci
+        imports: stacker://build/umoci.static
+        run: cp /stacker/imports/umoci.static /usr/bin/umoci
 
 Will build a static version of umoci in an ubuntu container, but the final
 image will only contain an `umoci` tag with a statically linked version of
@@ -165,7 +165,7 @@ indicates that the container shouldn't be emitted in the final image, because
 we're going to import something from it and don't need the rest of it. The
 line:
 
-    import: stacker://build/umoci.static
+    imports: stacker://build/umoci.static
 
 is what actually does this import, and it says "from a previously built stacker
 image called 'build', import /umoci.static".

--- a/pkg/stacker/cache.go
+++ b/pkg/stacker/cache.go
@@ -22,7 +22,7 @@ import (
 	"stackerbuild.io/stacker/pkg/types"
 )
 
-const currentCacheVersion = 12
+const currentCacheVersion = 13
 
 type ImportType int
 

--- a/pkg/stacker/cache_test.go
+++ b/pkg/stacker/cache_test.go
@@ -125,5 +125,5 @@ func TestCacheEntryChanged(t *testing.T) {
 	// This test works because the type information is included in the
 	// hashstructure hash above, so using a zero valued CacheEntry is
 	// enough to capture changes in types.
-	assert.Equal(uint64(0x5b52c6b8e076304c), h)
+	assert.Equal(uint64(0x4ef432528243e356), h)
 }

--- a/pkg/types/stackerfile.go
+++ b/pkg/types/stackerfile.go
@@ -15,6 +15,12 @@ import (
 	"stackerbuild.io/stacker/pkg/log"
 )
 
+const (
+	InternalStackerDir       = "/stacker"
+	LegacyInternalStackerDir = "/.stacker"
+	BinStacker               = "bin/stacker"
+)
+
 type BuildConfig struct {
 	Prerequisites []string `yaml:"prerequisites"`
 }
@@ -209,6 +215,14 @@ func NewStackerfile(stackerfile string, validateHash bool, substitutions []strin
 	sf.internal, err = parseLayers(sf.ReferenceDirectory, lms, validateHash)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, name := range sf.FileOrder {
+		layer := sf.internal[name]
+		if layer.WasLegacyImport() {
+			log.Warnf("Deprecated 'import' directive used in layer '%s' of file '%s'. "+
+				"Change from 'import' to 'imports', and '/stacker/' to '/stacker/imports/'", name, stackerfile)
+		}
 	}
 
 	return &sf, err

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -14,7 +14,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import: import
+    imports: import
 EOF
     echo 1 > import
     stacker build
@@ -32,7 +32,7 @@ busybox:
     from:
         type: tar
         url: .stacker/layer-bases/busybox.tar
-    import:
+    imports:
         - ./stacker.yaml
         - https://www.cisco.com/favicon.ico
         - ./executable
@@ -199,6 +199,7 @@ busybox:
         type: tar
         url: .stacker/layer-bases/busybox.tar
     import:
+    imports:
         - ./stacker.yaml
         - https://www.cisco.com/favicon.ico
         - ./executable

--- a/test/broken-link.bats
+++ b/test/broken-link.bats
@@ -15,7 +15,7 @@ broken_link:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - dir
     run: cp -a /stacker/imports/dir/testln /testln
 EOF

--- a/test/build-only.bats
+++ b/test/build-only.bats
@@ -83,7 +83,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import: https://www.cisco.com/favicon.ico
+    imports: https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico
     build_only: true
@@ -91,7 +91,7 @@ layer1:
     from:
         type: built
         tag: busybox
-    import:
+    imports:
         - stacker://busybox/favicon.ico
     run:
         - cp /stacker/imports/favicon.ico /favicon2.ico
@@ -108,7 +108,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import: https://www.cisco.com/favicon.ico
+    imports: https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico
     build_only: true
@@ -116,7 +116,7 @@ layer1:
     from:
         type: built
         tag: busybox
-    import:
+    imports:
         - stacker://busybox/favicon.ico
     run:
         - cp /stacker/imports/favicon.ico /favicon2.ico

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -52,7 +52,7 @@ base:
     from:
         type: built
         tag: build-base
-    import:
+    imports:
         - foo
     run: |
         cp /stacker/imports/foo /foo
@@ -71,7 +71,7 @@ import-cache:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - link/foo
     run: cp /stacker/imports/foo/zomg /zomg
 EOF
@@ -95,7 +95,7 @@ a:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - foo
     run: |
         [ -f /stacker/imports/foo/bar ]
@@ -111,7 +111,7 @@ a:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - foo
     run: |
         [ ! -f /stacker/imports/foo/bar ]
@@ -126,7 +126,7 @@ bind-test:
     from:
         type: oci
         url: ${{BUSYBOX_OCI}}
-    import:
+    imports:
         - tree1/foo/zomg
     binds:
         - ${{bind_path}} -> /root/tree2/foo
@@ -169,7 +169,7 @@ mode-test:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - executable
     run: cp /stacker/imports/executable /executable
 EOF
@@ -185,6 +185,7 @@ EOF
 }
 
 @test "can read previous version's cache" {
+    skip "old version does not support imports (plural) directive"
     # some additional testing that the cache can be read by older versions of
     # stacker (cache_test.go has the full test for the type, this just checks
     # the mechanics of filepaths and such)
@@ -204,7 +205,7 @@ test:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - foo
     run: cp /stacker/imports/foo /foo
 EOF

--- a/test/cp-not-required.bats
+++ b/test/cp-not-required.bats
@@ -27,7 +27,7 @@ contents2:
     from:
         type: built
         tag: build
-    import:
+    imports:
         - stacker://contents/first
         - stacker://contents/second
     run: |

--- a/test/dependency-order.bats
+++ b/test/dependency-order.bats
@@ -27,7 +27,7 @@ test:
     from:
         type: oci
         tag: $BUSYBOX_OCI
-    import:
+    imports:
         - stacker://foo/bar
         - stacker://baz/foo
 EOF
@@ -74,7 +74,7 @@ installer-iso-build:
         type: built
         tag: minbase1
     build_only: true
-    import:
+    imports:
         - stacker://installer-initrd/output/installer-initrd-base.cpio
         - stacker://installer-initrd-modules/output/installer-initrd-modules.cpio
     run: |

--- a/test/docker-base.bats
+++ b/test/docker-base.bats
@@ -14,7 +14,7 @@ busybox:
     from:
         type: docker
         url: oci:${BUSYBOX_OCI}
-    import:
+    imports:
         - https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico

--- a/test/import-http.bats
+++ b/test/import-http.bats
@@ -23,7 +23,7 @@ img:
     from:
         type: oci
         url: $(pwd)/oci:busybox_base
-    import:
+    imports:
         - http://network-test.debian.org/nm
     run: |
         cp /stacker/imports/nm /root/nm
@@ -79,7 +79,7 @@ busybox_base:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.cisco.com/favicon.ico
           dest: /dest/icon
     run: |

--- a/test/import.bats
+++ b/test/import.bats
@@ -15,7 +15,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - https://bing.com/favicon.ico
 EOF
     stacker build
@@ -35,7 +35,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - recursive
     run: |
         [ -d /stacker/imports/recursive ]
@@ -53,7 +53,7 @@ first:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - recursive
     run: |
         [ -d /stacker/imports/recursive ]
@@ -63,7 +63,7 @@ second:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - stacker://first/recursive
     run: |
         [ -d /stacker/imports/recursive ]
@@ -82,7 +82,7 @@ first:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: test_file
           hash: $test_file_sha
         - test_file2
@@ -96,7 +96,7 @@ second:
     from:
         type: built
         tag: first
-    import:
+    imports:
         - path: stacker://first/test_file
           hash: $test_file_sha
     run: |
@@ -113,7 +113,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: test_file
           hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b856
 EOF
@@ -128,7 +128,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: test_file
           hash: 1234abcdef
 EOF
@@ -145,7 +145,7 @@ first:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: test_file
           hash: $test_file_sha
     run: |
@@ -155,7 +155,7 @@ second:
     from:
         type: built
         tag: first
-    import:
+    imports:
         - path: stacker://first/test_file
           hash: $test_file_sha_upper
     run: |
@@ -173,7 +173,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.google.com/favicon.ico
           hash: $google_sha
     run: |
@@ -190,7 +190,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.google.com/favicon.ico
           hash: 0d4856785d1d3c3aad3e5311e654c70c19d335f927c24ebb89dfcd52b2d988cb
 EOF
@@ -209,7 +209,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.google.com/favicon.ico
           hash: $google_sha
         - path: test_file
@@ -232,7 +232,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.google.com/favicon.ico
         - path: test_file
           hash: $test_file_sha
@@ -250,7 +250,7 @@ thing:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: https://www.google.com/favicon.ico
           hash: $google_sha
         - path: test_file
@@ -265,7 +265,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - "zomg"
         - - "one"
           - "two"
@@ -279,7 +279,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - dir
     run: |
         find /stacker
@@ -307,7 +307,7 @@ first:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - path: test_file
           hash: $test_file_sha
         - test_file2
@@ -321,7 +321,7 @@ second:
     from:
         type: built
         tag: first
-    import:
+    imports:
         - path: stacker://first/test_file
           perms: 0777
           hash: $test_file_sha
@@ -330,7 +330,7 @@ second:
 third:
     from:
         type: scratch
-    import:
+    imports:
         - path: stacker://first/test_file
           mode: 0777
           hash: $test_file_sha
@@ -338,7 +338,7 @@ third:
 fourth:
     from:
         type: scratch
-    import:
+    imports:
         - path: test_file
           hash: $test_file_sha
           mode: 0777
@@ -348,7 +348,7 @@ fourth:
 fifth:
   from:
     type: scratch
-  import:
+  imports:
     - path: test_file
       dest: /files/
     - path: test_file2
@@ -357,7 +357,7 @@ sixth:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
     - stacker://fifth/files/test_file
     - stacker://fifth/file2
   run: |
@@ -365,7 +365,7 @@ sixth:
 seventh:
   from:
     type: scratch
-  import:
+  imports:
     - path: test_file
       dest: /files/
     - path: test_file2
@@ -376,7 +376,7 @@ eigth:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
     - path: test_file
       dest: /dir/files/
     - path: test_file2
@@ -403,7 +403,7 @@ first:
   from:
     type: oci
     url: $BUSYBOX_OCI
-  import:
+  imports:
   - path: folder1/
     dest: /folder1/
   run: |
@@ -422,7 +422,7 @@ third:
   from:
     type: oci
     url: $BUSYBOX_OCI
-  import:
+  imports:
     - path: stacker://second/folder1/
       dest: /folder1/
   run: |
@@ -433,7 +433,7 @@ fourth:
   from:
     type: oci
     url: $BUSYBOX_OCI
-  import:
+  imports:
   - path: folder1/
     dest: /
   run: |
@@ -446,7 +446,7 @@ fifth:
   from:
     type: oci
     url: $BUSYBOX_OCI
-  import:
+  imports:
   - path: folder1/subfolder2/
     dest: /folder3/
   - path: folder1/subfolder2
@@ -477,7 +477,7 @@ src_folder_dest_non_existent_folder_case1:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
   - path: folder1
     dest: /folder2
   run: |
@@ -487,7 +487,7 @@ src_folder_dest_non_existent_folder_case2:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
   - path: folder1/
     dest: /folder2
   run: |
@@ -497,7 +497,7 @@ src_folder_dest_non_existent_folder_case3:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
   - path: folder1
     dest: /folder2/
   run: |
@@ -509,11 +509,38 @@ src_folder_dest_non_existent_folder_case4:
   from:
     type: docker
     url: oci:${UBUNTU_OCI}
-  import:
+  imports:
   - path: folder1/
     dest: /folder2/
   run: |
     [ -f /folder2/file1 ]
 EOF
   stacker build
+}
+
+@test "legacy imports" {
+    echo "file1-content" > file1.txt
+    cat > stacker.yaml <<EOF
+legacyimports:
+  from:
+    type: oci
+    url: $CENTOS_OCI
+  # the deprecated singular 'import' directive puts content in /stacker
+  import:
+    - file1.txt
+  run: |
+    [ -f /stacker/file1.txt ]
+
+newimports:
+  from:
+    type: oci
+    url: $CENTOS_OCI
+  # the plural 'imports' directive puts things in /stacker/imports
+  imports:
+    - file1.txt
+  run: |
+    [ -f /stacker/imports/file1.txt ]
+EOF
+
+    stacker build
 }

--- a/test/invalid.bats
+++ b/test/invalid.bats
@@ -14,7 +14,7 @@ bad:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - stacker://idontexist/file
 EOF
     bad_stacker build

--- a/test/multi-arch.bats
+++ b/test/multi-arch.bats
@@ -16,7 +16,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - https://www.cisco.com/favicon.ico
 EOF
     stacker build
@@ -36,7 +36,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - https://www.cisco.com/favicon.ico
 EOF
     bad_stacker build

--- a/test/overlay-dirs.bats
+++ b/test/overlay-dirs.bats
@@ -51,7 +51,7 @@ second:
     from:
         type: built
         tag: first
-    import: stacker://first/file
+    imports: stacker://first/file
     run: |
         [ -f /stacker/imports/file ]
 EOF

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -9,7 +9,7 @@ layer1_1:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - import1
     run: |
         cp /stacker/imports/import1 /root/import1
@@ -30,7 +30,7 @@ layer2:
     from:
         type: built
         tag: layer1_1
-    import:
+    imports:
         - import2
     run: |
         cp /stacker/imports/import2 /root/import2

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -9,7 +9,7 @@ layer1:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - import1
     run: |
         cp /stacker/imports/import1 /root/import1
@@ -24,7 +24,7 @@ layer2:
     from:
         type: built
         tag: layer1
-    import:
+    imports:
         - import2
     run: |
         cp /stacker/imports/import2 /root/import2

--- a/test/squashfs.bats
+++ b/test/squashfs.bats
@@ -143,7 +143,7 @@ importer:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - stacker://build/bin/ls
     run: |
         /stacker/imports/ls
@@ -259,7 +259,7 @@ demo-zot:
   from:
     type: built
     tag: install-rootfs-pkg
-  import:
+  imports:
     - x
   run: |
     #!/bin/sh -ex

--- a/test/unprivileged.bats
+++ b/test/unprivileged.bats
@@ -42,7 +42,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico
@@ -74,7 +74,7 @@ busybox:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - import
 EOF
     stacker build
@@ -96,7 +96,7 @@ base:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - first
         - second
     run: |
@@ -126,7 +126,7 @@ base:
     from:
         type: oci
         url: $BUSYBOX_OCI
-    import:
+    imports:
         - test
     run: cat /stacker/imports/test
 EOF


### PR DESCRIPTION
This changes the behavior of the 'import' target to behave as it did before the breaking change that moved imports into /stacker/imports/

So now, if the stacker file uses 'import', then imports will be placed in /stacker.  If the stacker file uses 'imports' (plural) then they will be placed in /stacker/imports.

What we actually get in both cases is all the binds being done into either /.stacker (legacy) or /stacker (new).  In the legacy case, the imports are also bind-mounted into /stacker

Legacy (for those that used 'import:')

     stacker: /.stacker/bin/stacker
     imports: /.stacker/imports -> /stacker
     runscript: /.stacker/imports/.stacker-run.sh
     artifacts: /.stacker/artifacts

new (for those that use 'imports:')

     stacker: /stacker/bin/stacker
     imports: /stacker/imports
     runscript: /stacker/imports/.stacker-run.sh
     artifacts: /stacker/artifacts

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
