### PR TITLE
test: drop references to docker:// images from test/

### DIFF
--- a/test/cp-not-required.bats
+++ b/test/cp-not-required.bats
@@ -13,7 +13,7 @@ function teardown() {
 build:
     from:
         type: docker
-        url: docker://ubuntu:latest
+        url: oci:${UBUNTU_OCI}
     run: |
         touch /tmp/first
         touch /tmp/second

--- a/test/docker-base.bats
+++ b/test/docker-base.bats
@@ -13,7 +13,7 @@ function teardown() {
 centos:
     from:
         type: docker
-        url: docker://centos:latest
+        url: oci:${CENTOS_OCI}
     import:
         - https://www.cisco.com/favicon.ico
     run: |

--- a/test/import.bats
+++ b/test/import.bats
@@ -356,7 +356,7 @@ fifth:
 sixth:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
     - stacker://fifth/files/test_file
     - stacker://fifth/file2
@@ -375,7 +375,7 @@ seventh:
 eigth:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
     - path: test_file
       dest: /dir/files/
@@ -476,7 +476,7 @@ EOF
 src_folder_dest_non_existent_folder_case1:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
   - path: folder1
     dest: /folder2
@@ -486,7 +486,7 @@ src_folder_dest_non_existent_folder_case1:
 src_folder_dest_non_existent_folder_case2:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
   - path: folder1/
     dest: /folder2
@@ -496,7 +496,7 @@ src_folder_dest_non_existent_folder_case2:
 src_folder_dest_non_existent_folder_case3:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
   - path: folder1
     dest: /folder2/
@@ -508,7 +508,7 @@ src_folder_dest_non_existent_folder_case3:
 src_folder_dest_non_existent_folder_case4:
   from:
     type: docker
-    url: docker://ubuntu:latest
+    url: oci:${UBUNTU_OCI}
   import:
   - path: folder1/
     dest: /folder2/


### PR DESCRIPTION
Some tests were using

   type: docker
   url: docker://ubuntu:latest

Rather than using:

   type: oci
   url: oci:${UBUNTU_OCI}

Replacing those with the oci reference drops a test runtime dependency we have on docker hub.

I've left the 'type' of docker in place to test a code path that uses 'type: docker' to refer to 'oci:'.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
