### PR TITLE
test: add code coverage support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,3 +13,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       slow-test: false
+  coverage:
+    uses: ./.github/workflows/coverage.yaml
+    with:
+      slow-test: false

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,105 @@
+name: Reusable stacker build for coverage
+on:
+  workflow_call:
+    inputs:
+      # note >-, args needs to be strings to be used as inputs
+      # for the reusable build.yaml workflow
+      go-version:
+        required: false
+        type: string
+        description: 'Stringified JSON object listing go versions'
+        default: >-
+          ["1.20.x"]
+      privilege-level:
+        required: false
+        type: string
+        description: 'Stringified JSON object listing stacker privilege-level'
+        default: >-
+          ["unpriv", "priv"]
+      build-id:
+        required: false
+        type: string
+        description: 'build-id'
+        default: "${{ github.sha }}"
+      slow-test:
+        required: false
+        type: boolean
+        description: 'Should slow tests be run?'
+        default: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    services:
+      registry:
+        image: ghcr.io/project-stacker/registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        go-version: ${{fromJson(inputs.go-version)}}
+        privilege-level: ${{fromJson(inputs.privilege-level)}}
+    name: "golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean disk space
+        uses: ./.github/actions/clean-runner
+      - uses: benjlevesque/short-sha@v2.1
+        id: short-sha
+      - name: Set up golang ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Setup Environment
+        run: |
+          gopath=$PWD/.build/gopath
+          echo "GOPATH=$gopath" >> $GITHUB_ENV
+          echo "GOCACHE=$gopath/gocache" >> $GITHUB_ENV
+          echo "PATH=$gopath/bin:$PATH" >> $GITHUB_ENV
+          echo "SLOW_TEST=${{inputs.slow-test}}" >> $GITHUB_ENV
+          echo "STACKER_DOCKER_BASE=oci:$PWD/.build/oci-clone:" >> $GITHUB_ENV
+          GOCOVERDIR=$(mktemp -d)
+          echo "GOCOVERDIR=$GOCOVERDIR" >> $GITHUB_ENV
+          echo "PWD=$PWD"
+          cat "$GITHUB_ENV"
+      - name: install dependencies
+        run: |
+          ./install-build-deps.sh
+          echo "running kernel is: $(uname -a)"
+      - name: docker-clone
+        run: |
+          make docker-clone "STACKER_DOCKER_BASE=docker://" CLONE_D="$PWD/.build/oci-clone"
+      - name: Go-download
+        run: |
+          make go-download
+      - name: Show disk usage before building the binaries
+        uses: ./.github/actions/show-disk-usage
+      - name: Build-level1
+        run: |
+          make show-info
+          make stacker-dynamic VERSION_FULL=${{ inputs.build-id }}
+      - name: Show disk usage before running the tests
+        if: always()
+        uses: ./.github/actions/show-disk-usage
+      - name: Build and test
+        run: |
+          make check-cov GOCOVERDIR=$GOCOVERDIR PRIVILEGE_LEVEL=${{ matrix.privilege-level }}
+          go tool covdata textfmt -i $GOCOVERDIR -o coverage-${{ matrix.privilege-level }}.txt
+          go tool covdata percent -i $GOCOVERDIR
+          ls -altR $GOCOVERDIR
+        env:
+          REGISTRY_URL: localhost:5000
+          ZOT_HOST: localhost
+          ZOT_PORT: 8080
+      - name: Show disk usage after running the tests
+        if: always()
+        uses: ./.github/actions/show-disk-usage
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage-${{ matrix.privilege-level}}.txt
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: stacker
+          key: ${{ inputs.build-id }}

--- a/build.yaml
+++ b/build.yaml
@@ -93,4 +93,8 @@ build:
     cd /stacker-tree
     make BUILD_D=/build show-info
     make BUILD_D=/build -C cmd/stacker/lxc-wrapper clean
-    make BUILD_D=/build stacker-static
+    if [ x${{WITH_COV}} = x"yes" ]; then
+      make BUILD_D=/build stacker-static-cov
+    else
+      make -C /stacker-tree stacker-static
+    fi

--- a/pkg/test/cover.go
+++ b/pkg/test/cover.go
@@ -1,0 +1,19 @@
+package test
+
+import "os"
+
+const CoverageBindPath = "/stacker/.coverage"
+
+func IsCoverageEnabled() bool {
+	_, ok := os.LookupEnv("GOCOVERDIR")
+	return ok
+}
+
+func GetCoverageDir() string {
+	val, ok := os.LookupEnv("GOCOVERDIR")
+	if ok {
+		return val
+	}
+
+	return ""
+}


### PR DESCRIPTION
With golang 1.20.x, we can build a binary with coverage support.

> Cover
>
> Go 1.20 supports collecting code coverage profiles for programs
> (applications and integration tests), as opposed to just unit tests.
> 
> To collect coverage data for a program, build it with go build's -cover
> flag, then run the resulting binary with the environment variable
> GOCOVERDIR set to an output directory for coverage profiles. See the
> 'coverage for integration tests' landing page for more on how to get
> started. For details on the design and implementation, see the
> proposal.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
