### PR TITLE
test: Fix the docker-clone make target to exit failure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,16 +142,10 @@ test: stacker $(REGCLIENT) $(SKOPEO) $(ZOT)
 		$(patsubst %,test/%.bats,$(TEST))
 
 
-CLONE_D = $(BUILD_D)/oci-clone
-CLONE_RETRIES = 3
 .PHONY: docker-clone
 docker-clone:
-	mkdir -p $(CLONE_D)
-	vr() { echo "$$" "$$@" 1>&2; "$$@"; }; \
-	for u in $(STACKER_BUILD_IMAGES); do \
-		name=$${u$(HASH)$(HASH)*/}; \
-		vr skopeo copy --retry-times $(CLONE_RETRIES) "$$u" "oci:$(CLONE_D):$${name}"; \
-	done
+	./tools/oci-copy "$(BUILD_D)/oci-clone" $(STACKER_BUILD_IMAGES)
+
 
 .PHONY: show-info
 show-info:

--- a/tools/oci-copy
+++ b/tools/oci-copy
@@ -1,0 +1,42 @@
+#!/bin/sh
+# vi: ts=4 expandtab
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} oci-dir image [image [...]]
+
+Copy each 'image' into oci repo in 'oci-dir'.
+
+Example:
+    ${0##*/} ./my-oci.d docker://busybox:latest
+EOF
+}
+
+stderr() { echo "$@" 1>&2; }
+
+fail() { [ $# -eq 0 ] || stderr "$@"; exit 1; }
+
+vr() {
+    stderr "$" "$@"
+    "$@" && return 0
+    fail "FAIL[$?]: $*"
+}
+
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && { Usage; exit 0; }
+[ $# -ge 2 ] || {
+    Usage 1>&2;
+    fail "Got $# args, expected 2 or more";
+}
+
+oci_d="$1"
+shift
+
+command -v skopeo >/dev/null 2>&1 ||
+    fail "no 'skopeo' in PATH"
+
+mkdir -p "$oci_d" || fail "failed to create dir '$oci_d'"
+for url in "$@"; do
+    name=${url##*/};
+    vr skopeo copy --retry-times=3 "$url" "oci:${oci_d}:$name" ||
+        fail "Failed to copy '$url' to 'oci:${oci_d}:$name'"
+done
+exit 0


### PR DESCRIPTION
test: Fix the docker-clone make target to exit failure.

My expectation was that when make invoked the shell (sh) for
a line in a rule was that it did so with '-e'.  That was an
incorrect assumption.

The make docker-clone target was basically doing:

    for i in url1 url2 url3; do
        something $i; done

The failure of the *last* item in the list should cause the
command to exit failure, but failure of an earlier command would not.

The change here is just to move that shell code into a script in
tools/oci-copy and call it from there.
