### PR TITLE
fix(gzip)!: change the default block size (#529)

### DIFF
--- a/pkg/overlay/pack.go
+++ b/pkg/overlay/pack.go
@@ -29,6 +29,12 @@ import (
 	"stackerbuild.io/stacker/pkg/types"
 )
 
+// Container image layers are often tar.gz, however there is nothing in the
+// spec or documentation which standardizes compression params which can cause
+// different layer hashes even for the same tar. So picking compression params
+// that most tooling appears to be using.
+const gzipBlockSize = mutate.GzipBlockSize(256 << 12)
+
 func safeOverlayName(d digest.Digest) string {
 	// dirs used in overlay lowerdir args can't have : in them, so lets
 	// sanitize it
@@ -418,7 +424,7 @@ func generateLayer(config types.StackerConfig, oci casext.Engine, mutators []*mu
 		defer blob.Close()
 
 		if layerType.Type == "tar" {
-			desc, err = mutator.Add(context.Background(), mediaType, blob, history, mutate.GzipCompressor, nil)
+			desc, err = mutator.Add(context.Background(), mediaType, blob, history, mutate.GzipCompressor.WithOpt(gzipBlockSize), nil)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
BREAKING CHANGE: the default gzip block size is changed to 256<<12, was previously 256<<10.

A tar layer with the same content but compressed with different gzip blocksize will result in different sha256sums in the final OCI Image. Ecosystem tools have one current size in use and stacker's current size differ.

Interactions between a stacker-built OCI image and ecosystem tools which recompress lower layers results in bloated registries which will have identical tar content but different compressed sha256 blobs.

Unfortunately, the OCI image spec doesn't standardize/encode this in the specification document. Hence, we change to the current common block size used in the ecosystem here in the stacker implementation.

We now link against our own fork: github.com/project-stacker/umoci which may change depending on the PR getting merged to upstream.


(cherry picked from commit 0cf2d706d0505efa743e1b42c8ad248e774df0ab)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
