### PR TITLE
test: Fix test failure due to .coverage changing during tar creation.

### DIFF
--- a/test/dependency-order.bats
+++ b/test/dependency-order.bats
@@ -81,7 +81,7 @@ installer-iso-build:
         #!/bin/bash -ex
         # populate the iso
         mkdir /output
-        tar -cf /output/installer-iso.tar -C /stacker .
+        ( cd /stacker/imports && tar -cf /output/installer-iso.tar *.cpio )
 
 atomix-installer-iso:
     from:


### PR DESCRIPTION
This seems to be a transient failure, but is legitimate issue.

When coverage binary is being used, this test case could fail with:

    #  + mkdir /output
    # + tar -cf /output/installer-iso.tar -C /stacker .
    # tar: ./.coverage: file changed as we read it

The /stacker/.coverage file was being updated by the stacker binary itself.  This is just a race condition based on when the file gets written to and when it was being collected by tar.

The change is just to only have tar collect the .cpio files.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
