### PR TITLE
ci: Only upload coverage when running coverage workflow, not build.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,8 +97,6 @@ jobs:
       - name: Show disk usage after running the tests
         if: always()
         uses: ./.github/actions/show-disk-usage
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v3
       - uses: actions/cache@v3
         id: restore-build
         with:


### PR DESCRIPTION
I had a pull request (#557) that changed a single line in a single integration test.  c-i reported that coverage changed:
   5.72% (-48.53%) compared to a34ebfa
Where a34ebfa was the previous commit.

That doesn't sound right.  I think what is happening is that we have multiple uploads of the coverage workflow and they're fighting.

There isn't any reason to upload both anyway.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
