### PR TITLE
Fix/556 grab side effect

### DIFF
--- a/test/grab.bats
+++ b/test/grab.bats
@@ -1,0 +1,49 @@
+load helpers
+
+function setup() {
+    stacker_setup
+}
+
+function teardown() {
+    cleanup
+}
+
+# do a build and a grab in an empty directory and
+# verify that no unexpected files are created.
+@test "grab has no side-effects" {
+    cat > stacker.yaml <<EOF
+layer1:
+    from:
+        type: oci
+        url: $BUSYBOX_OCI
+    imports:
+        - myfile.txt
+    run: |
+        cp /stacker/imports/myfile.txt /my-file
+EOF
+    startdir="$PWD"
+    wkdir="$PWD/work-dir"
+    bdir="$PWD/build-dir"
+    grabdir="$PWD/grab-dir"
+    mkdir "$wkdir" "$grabdir" "$bdir"
+    give_user_ownership "$wkdir" "$grabdir" "$bdir"
+
+    echo "hello world" > myfile.txt
+    expected_sha=$(sha myfile.txt)
+
+    cd "$bdir"
+    stacker "--work-dir=$wkdir" build "--stacker-file=$startdir/stacker.yaml"
+    dir_is_empty . ||
+        test_error "build dir had unexpected files: $_RET_EXTRA"
+
+    cd "$grabdir"
+    stacker "--work-dir=$wkdir" grab layer1:/my-file
+    [ -f my-file ]
+    found_sha=$(sha my-file)
+    [ "${expected_sha}" = "${found_sha}" ]
+
+    dir_has_only . my-file ||
+        test_error "grab produced extra files." \
+            "missing=${_RET_MISSING} extra=${_RET_EXTRA}"
+}
+


### PR DESCRIPTION
  * fix: Remove the bin/ dir that was created as a side-effect of grab.
    
    'stacker grab' was creating a 'bin/' dir in the current working
    directory.  This fixes that and adds a test to ensure that neither
    grab nor build have side effects.
    
    Fixes #566.
    
  * test: separate detection of overlay support from every stacker run.
    
    In unpriv test mode, we were running 'stacker testsuite-check-overlay'
    every time we ran stacker.
    
    That was causing me confusion and also is just wasteful, as the ability
    to use overlay does not change within the course of a test run.
    
    This introduces 'suite_setup' which ideally would be used by the bats
    'suite_setup' functionality.  However, the Ubuntu 22.04 verison of bats
    does not *have* that functionalty.
    
    When run with '-j', this code will run more than once, but will worst
    case only run once per test, rather than once per invocation of
    'stacker' (some tests invoke stacker many times).
    
    Also, adjust output of run_stacker function to be more useful
    than just "Debug mode: "
