### PR TITLE
fix: Update 'import' deprecation warning with a date.

### DIFF
--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -138,6 +138,8 @@ The deprecated `import` directive works like `imports` except that
 the entries in the `import` array will be placed into `/stacker/` rather
 than `/stacker/imports`.
 
+See https://github.com/project-stacker/stacker/issues/571 for timeline and migration info.
+
 ### `overlay_dirs`
 This directive works only with OverlayFS backend storage.
 

--- a/pkg/types/stackerfile.go
+++ b/pkg/types/stackerfile.go
@@ -220,8 +220,11 @@ func NewStackerfile(stackerfile string, validateHash bool, substitutions []strin
 	for _, name := range sf.FileOrder {
 		layer := sf.internal[name]
 		if layer.WasLegacyImport() {
-			log.Warnf("Deprecated 'import' directive used in layer '%s' of file '%s'. "+
-				"Change from 'import' to 'imports', and '/stacker/' to '/stacker/imports/'", name, stackerfile)
+			log.Warnf("'import' directive used in layer '%s' inside file '%s' is deprecated. "+
+				"Support for 'import' will be removed in releases after 2025-01-01. "+
+				"Migrate by changing 'import' to 'imports' and '/stacker' to '/stacker/imports'. "+
+				"See https://github.com/project-stacker/stacker/issues/571 for migration.",
+				name, stackerfile)
 		}
 	}
 


### PR DESCRIPTION
Putting a date in the deprecation warning message allows users to plan migration more effectively.  The date chosen allows for plenty of time for users to migrate existing stacker.yaml files.

#571.