### PR TITLE
fix: use overlay whiteouts when extracting tar layers

### DIFF
--- a/pkg/overlay/pack.go
+++ b/pkg/overlay/pack.go
@@ -725,7 +725,9 @@ func unpackOne(l ispec.Descriptor, ociDir string, extractDir string) error {
 			return err
 		}
 
-		err = layer.UnpackLayer(extractDir, uncompressed, nil)
+		// always unpack with Overlay whiteout mode to prevent ignoring whiteouts in tar layers
+		// see test/publish.bats: "building from published images with whiteouts" for more details
+		err = layer.UnpackLayer(extractDir, uncompressed, &layer.UnpackOptions{WhiteoutMode: layer.OverlayFSWhiteout})
 		if err != nil {
 			if rmErr := os.RemoveAll(extractDir); rmErr != nil {
 				log.Errorf("Failed to remove dir '%s' after failed extraction: %v", extractDir, rmErr)

--- a/test/empty-layers.bats
+++ b/test/empty-layers.bats
@@ -77,6 +77,9 @@ EOF
 }
 
 @test "a real-world docker image with empty/filler layer" {
+    if [ "$PRIVILEGE_LEVEL" != "priv" ]; then
+        skip "requires privileges"
+    fi
     cat > stacker.yaml <<EOF
 image:
     from:


### PR DESCRIPTION
If a tar layer has a deleted file, a whiteout entry is created. However, when extracting tar and overlay whiteouts are incompatible.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
