### PR TITLE
fix: catch failures in makefile when building skopeo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ $(ZOT):
 	$(call dlbin,$@,https://github.com/project-zot/zot/releases/download/$(ZOT_VERSION)/zot-linux-amd64-minimal)
 
 $(SKOPEO):
-	@mkdir -p "$(TOOLS_D)/bin"; \
+	@set -e; mkdir -p "$(TOOLS_D)/bin"; \
 	tmpdir=$$(mktemp -d); \
 	cd $$tmpdir; \
 	git clone https://github.com/containers/skopeo.git; \


### PR DESCRIPTION
Skopeo's build target is an inline shell script.
It needs to run with 'set -e' or it will just keep going after it fails.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
