### PR TITLE
fix: don't break on --substitute values which have commas

### DIFF
--- a/cmd/stacker/main.go
+++ b/cmd/stacker/main.go
@@ -123,6 +123,8 @@ func main() {
 		&checkCmd,
 	}
 
+	app.DisableSliceFlagSeparator = true
+
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  "work-dir",

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -304,3 +304,15 @@ EOF
     [ ! -f dest/rootfs/favicon.ico ]
     [ ! -d dest/rootfs/stacker ]
 }
+
+@test "commas in substitute flags ok" {
+    cat > stacker.yaml <<EOF
+busybox:
+    from:
+        type: oci
+        url: $BUSYBOX_OCI
+    run: |
+        touch /foo
+EOF
+    stacker build --substitute "a=b,c"
+}


### PR DESCRIPTION
The following:

  stacker build --substitute a=b,c

used to work, until commit 3baba644:

  fix(ci): convert ci is failing due to perms (#439)

This squashed PR included 'chore(go.mod): update cli to github.com/urfave/cli/v2'.  Switching from urfave/cli/v1 to v2 changes string slice flag behavior to automatically split on commas.

Luckily there is an app.DisableSliceFlagSeparator flag we can set to tell it not to do that.  Set that flag.  And add a test for this.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
