### PR TITLE
feat: add namespace arg when producing doc

### DIFF
--- a/cmd/stacker/bom.go
+++ b/cmd/stacker/bom.go
@@ -90,18 +90,19 @@ func doBomBuild(ctx *cli.Context) error {
 }
 
 func doBomVerify(ctx *cli.Context) error {
-	if ctx.Args().Len() != 4 {
+	if ctx.Args().Len() != 5 {
 		return errors.Errorf("wrong number of args")
 	}
 
 	dest := ctx.Args().Get(0)
-	name := ctx.Args().Get(1)
-	author := ctx.Args().Get(2)
-	org := ctx.Args().Get(3)
+	namespace := ctx.Args().Get(1)
+	name := ctx.Args().Get(2)
+	author := ctx.Args().Get(3)
+	org := ctx.Args().Get(4)
 
 	// first merge all individual sbom artifacts that may have been generated
 	iDir := types.InternalStackerDir
-	if err := bom.MergeDocuments(iDir+"/artifacts", name, author, org, dest); err != nil {
+	if err := bom.MergeDocuments(iDir+"/artifacts", namespace, name, author, org, dest); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -286,5 +286,5 @@ require (
 
 replace (
 	github.com/opencontainers/umoci => github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec
-	stackerbuild.io/stacker-bom => github.com/project-stacker/stacker-bom v0.0.6-0.20240118174508-52fb507e9d2e
+	stackerbuild.io/stacker-bom => github.com/project-stacker/stacker-bom v0.0.6-0.20240125170016-363073df9862
 )

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU0=
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
-github.com/project-stacker/stacker-bom v0.0.6-0.20240118174508-52fb507e9d2e h1:BYJ7UPVH+4YErCyfZGdUqMzp2wBeVGq26wNuohOEn4E=
-github.com/project-stacker/stacker-bom v0.0.6-0.20240118174508-52fb507e9d2e/go.mod h1:iKH3F0e8i3eNB6JbtGKv8qpgDSfUDUn+t8KoQ9Wf6pE=
+github.com/project-stacker/stacker-bom v0.0.6-0.20240125170016-363073df9862 h1:SFnn7tNrursXkAfIltfETcwVbX7mtM6qxnehoEbfgZ4=
+github.com/project-stacker/stacker-bom v0.0.6-0.20240125170016-363073df9862/go.mod h1:iKH3F0e8i3eNB6JbtGKv8qpgDSfUDUn+t8KoQ9Wf6pE=
 github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec h1:59Z20xRtwyzB7D/CRsueFkrIT1vJwWVtMe0riQb3kiE=
 github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec/go.mod h1:XUXUpCpA/Y8aJWezK1i8o4WDR0Y/vhMcWg+FUNQkKMQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/stacker/bom.go
+++ b/pkg/stacker/bom.go
@@ -93,6 +93,7 @@ func VerifyLayerArtifacts(sc types.StackerConfig, storage types.Storage, l types
 
 	cmd = append(cmd, "bom", "verify",
 		fmt.Sprintf(types.InternalStackerDir+"/artifacts/%s.json", tag),
+		l.Bom.Namespace,
 		tag, l.Annotations[types.AuthorAnnotation], l.Annotations[types.OrgAnnotation])
 
 	err = c.Execute(cmd, os.Stdin)

--- a/pkg/types/layer.go
+++ b/pkg/types/layer.go
@@ -69,8 +69,9 @@ type Package struct {
 }
 
 type Bom struct {
-	Generate bool      `yaml:"generate" json:"generate"`
-	Packages []Package `yaml:"packages" json:"packages,omitempty"`
+	Generate  bool      `yaml:"generate" json:"generate"`
+	Namespace string    `yaml:"namespace" json:"namespace"`
+	Packages  []Package `yaml:"packages" json:"packages,omitempty"`
 }
 
 func getStringOrStringSlice(data interface{}, xform func(string) ([]string, error)) ([]string, error) {
@@ -332,6 +333,10 @@ func parseLayers(referenceDirectory string, lms yaml.MapSlice, requireHash bool)
 		}
 
 		if layer.Bom != nil && layer.Bom.Generate {
+			if layer.Bom.Namespace == "" {
+				return nil, errors.Errorf("for bom generation, namespace must be set")
+			}
+
 			if layer.Annotations == nil {
 				return nil, errors.Errorf("for bom generation %s, %s and %s annotations must be set",
 					AuthorAnnotation, OrgAnnotation, LicenseAnnotation)

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -17,6 +17,7 @@ bom-parent:
         url: $CENTOS_OCI
     bom:
       generate: true
+      namespace: "https://test.io/artifacts"
       packages:
       - name: pkg1
         version: 1.0.0
@@ -75,6 +76,7 @@ bom-parent:
         url: $CENTOS_OCI
     bom:
       generate: true
+      namespace: "https://test.io/artifacts"
       packages:
       - name: pkg1
         version: 1.0.0
@@ -115,6 +117,7 @@ bom-child:
     tag: bom-parent
   bom:
     generate: true
+    namespace: "https://test.io/artifacts"
     packages:
     - name: pkg3
       version: 1.0.0
@@ -163,6 +166,7 @@ bom-alpine:
     url: $ALPINE_OCI
   bom:
     generate: true
+    namespace: "https://test.io/artifacts"
     packages:
       - name: pkg1
         version: 1.0.0


### PR DESCRIPTION
Currently, stacker-bom doesn't include namespace information in the document. Adding a cmdline arg to do so.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
