### PR TITLE
umoci: update to get tar writing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -285,6 +285,6 @@ require (
 )
 
 replace (
-	github.com/opencontainers/umoci => github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec
+	github.com/opencontainers/umoci => github.com/project-stacker/umoci v0.0.0-20240223003603-555a0af426e1
 	stackerbuild.io/stacker-bom => github.com/project-stacker/stacker-bom v0.0.6-0.20240227180605-9a3eb8f7f720
 )

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/project-stacker/stacker-bom v0.0.6-0.20240227180605-9a3eb8f7f720 h1:7XxHKp0cb8NfDVzZeP+Dgkx4/hdP6bXagwIRcZJNQiw=
 github.com/project-stacker/stacker-bom v0.0.6-0.20240227180605-9a3eb8f7f720/go.mod h1:Z6NhOFXmg2+eBNU77lGAZkiJWyATXix3ZdEJ53Gbkws=
-github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec h1:59Z20xRtwyzB7D/CRsueFkrIT1vJwWVtMe0riQb3kiE=
-github.com/project-stacker/umoci v0.0.0-20240122204034-cb3aca58b2ec/go.mod h1:XUXUpCpA/Y8aJWezK1i8o4WDR0Y/vhMcWg+FUNQkKMQ=
+github.com/project-stacker/umoci v0.0.0-20240223003603-555a0af426e1 h1:TtJDnPCi3mZU56pILbuQbXwmC3EEUJgOSop8NVkAKUE=
+github.com/project-stacker/umoci v0.0.0-20240223003603-555a0af426e1/go.mod h1:XUXUpCpA/Y8aJWezK1i8o4WDR0Y/vhMcWg+FUNQkKMQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=


### PR DESCRIPTION
move umoci version to the commit with the fix for correctly closing tarwriter in all cases, avoiding creation of layers that make gnu tar sad.

**What type of PR is this?**
bug

**Which issue does this PR fix**:
```
$ tar tvzf oci/blobs/sha256/bc7f2c15116d3da36aa493221dcf736cbe027f64f3e32b157aafb83da7cba35e
...
-rw-r--r-- 0/0 32064 2024-02-21 19:44 var/log/faillog
-rw-rw-r-- 0/43 292584 2024-02-21 19:44 var/log/lastlog
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

**What does this PR do / Why do we need it**:

while golang based container tools ignore this EOF, which is fine because it only happens after the last file has been read, many scanners use gnu tar, which errors out and can cause problems.

**If an issue # is not available please add repro steps and logs showing the issue**:

see https://github.com/project-stacker/umoci/pull/4

**Testing done on this change**:

see https://github.com/project-stacker/umoci/pull/4

**Will this break upgrades or downgrades?**
no

**Does this PR introduce any user-facing change?**:
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
