### PR TITLE
2024.02.27/main/stricter substitutions

### DIFF
--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -11,19 +11,35 @@ processed in stacker as:
 
     1 2 3
 
-That is, variables of the form `$FOO` or `${FOO}` are supported, and variables
-with `${FOO:default}` a default value will evaluate to their default if not
-specified on the command line. It is an error to specify a `${FOO}` style
-without a default; to make the default an empty string, use `${FOO:}`.
+In order to avoid conflict with bash or POSIX shells in the `run` section, 
+only placeholders with two braces are supported, e.g. `${{FOO}}`.
+Placeholders with a default value like `${{FOO:default}}` will evaluate to their default if not
+specified on the command line or in a substitution file.
 
-In addition to substitutions provided on the command line, the following
-variables are also available with their values from either command
+Using a `${{FOO}}` placeholder without a default will result in an error if
+there is no substitution provided. If you want an empty string in that case, use
+an empty default: `${{FOO:}}`.
+
+In order to avoid confusion, it is also an error if a placeholder in the shell
+style (`$FOO` or `${FOO}`) is found when the same key has been provided as a
+substitution either via the command line (e.g. `--substitute FOO=bar`) or in a
+substitution file. An error will be printed that explains how to rewrite it:
+
+   error "A=B" was provided as a substitution and unsupported placeholder "${A}" was found. Replace "${A}" with "${{A}}" to use the substitution.
+
+Substitutions can also be specified in a yaml file given with the argument
+`--substitute-file`, with any number of key: value pairs:
+
+    FOO: bar
+    BAZ: bat
+
+In addition to substitutions provided on the command line or a file, the
+following variables are also available with their values from either command
 line flags or stacker-config file.
 
     STACKER_STACKER_DIR config name 'stacker_dir', cli flag '--stacker-dir'-
     STACKER_ROOTFS_DIR  config name 'rootfs_dir', cli flag '--roots-dir'
     STACKER_OCI_DIR     config name 'oci_dir', cli flag '--oci-dir'
-
 
 The stacker build environment will have the following environment variables
 available for reference:

--- a/test/annotations-namespace.bats
+++ b/test/annotations-namespace.bats
@@ -9,14 +9,14 @@ function teardown() {
 }
 
 @test "namespace arg works" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 thing:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: ls
 EOF
-    stacker build --annotations-namespace=namespace.example
+    stacker build --annotations-namespace=namespace.example --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 0 ]
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     namespace=$(cat oci/blobs/sha256/$manifest | jq -r .annotations | cut -f1 -d:)
@@ -24,14 +24,14 @@ EOF
 }
 
 @test "default namespace arg works" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 thing:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: ls
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 0 ]
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     namespace=$(cat oci/blobs/sha256/$manifest | jq -r .annotations | cut -f1 -d:)

--- a/test/annotations.bats
+++ b/test/annotations.bats
@@ -9,16 +9,16 @@ function teardown() {
 }
 
 @test "annotations work" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 thing:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: ls
     annotations:
       a.b.c.key: val
 EOF
-    stacker build 
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 0 ]
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     cat oci/blobs/sha256/$manifest | jq .

--- a/test/args.bats
+++ b/test/args.bats
@@ -9,11 +9,11 @@ function teardown() {
 }
 
 @test "workdir args" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 child:
     from:
         type: built
@@ -24,7 +24,7 @@ EOF
   # check defaults
   tmpdir=$(mktemp -d)
   chmod -R a+rwx $tmpdir
-  stacker --work-dir $tmpdir build
+  stacker --work-dir $tmpdir build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
   [ -d $tmpdir ]
   [ -d $tmpdir/.stacker ]
   [ -d $tmpdir/roots ]
@@ -36,7 +36,7 @@ EOF
   chmod -R a+rwx $tmpdir
   stackerdir=$(mktemp -d)
   chmod -R a+rwx $stackerdir
-  stacker --work-dir $tmpdir --stacker-dir $stackerdir build
+  stacker --work-dir $tmpdir --stacker-dir $stackerdir build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
   [ -d $tmpdir ]
   [ ! -d $tmpdir/.stacker ]
   [ -d $tmpdir/roots ]

--- a/test/asterisk.bats
+++ b/test/asterisk.bats
@@ -9,16 +9,16 @@ function teardown() {
 }
 
 @test "wildcards work in run section" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 a:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         mkdir /mybin
         cp /bin/* /mybin
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:a dest
     [ "$status" -eq 0 ]
 

--- a/test/atomfs.bats
+++ b/test/atomfs.bats
@@ -29,15 +29,15 @@ function basic_test() {
     require_privilege priv
     local verity_arg=$1
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /hello
 EOF
-    stacker build --layer-type=squashfs $verity_arg
+    stacker build --layer-type=squashfs $verity_arg --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     mkdir mountpoint
     stacker internal-go atomfs mount test-squashfs mountpoint
 
@@ -63,11 +63,11 @@ EOF
 
 @test "mount + umount + mount a tree of images works" {
     require_privilege priv
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 base:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: touch /base
 a:
     from:
@@ -85,7 +85,7 @@ c:
         tag: base
     run: touch /c
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     mkdir a
     stacker internal-go atomfs mount a-squashfs a
@@ -137,15 +137,15 @@ EOF
 
 @test "bad existing verity device is rejected" {
     require_privilege priv
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /hello
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     first_layer_hash=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -9,25 +9,25 @@ function teardown() {
 }
 
 @test "multiple stacker builds in a row" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports: import
 EOF
     echo 1 > import
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo 2 > import
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo 3 > import
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo 4 > import
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "basic workings" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: tar
@@ -37,7 +37,7 @@ busybox:
         - https://www.cisco.com/favicon.ico
         - ./executable
     run:
-        - cp /stacker/imports/\$FAVICON /\$FAVICON
+        - cp /stacker/imports/${{FAVICON}} ${{FAVICON}}
         - ls -al /stacker
         - cp /stacker/imports/executable /usr/bin/executable
     entrypoint: echo hello world
@@ -103,7 +103,7 @@ EOF
     cat oci/blobs/sha256/$manifest | jq -r '.annotations."io.stackeroci.stacker.stacker_yaml"' | sed '$ d' > stacker_yaml_annotation
 
     # now we need to do --substitute FAVICON=favicon.ico
-    sed -e 's/$FAVICON/favicon.ico/g' stacker.yaml > stacker_after_subs
+    sed -e 's/${{FAVICON}}/favicon.ico/g' stacker.yaml > stacker_after_subs
 
     diff -U5 stacker_yaml_annotation stacker_after_subs
 
@@ -139,15 +139,15 @@ EOF
 }
 
 @test "stacker.yaml without imports can run" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /foo
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:busybox dest
     [ -f dest/rootfs/foo ]
 }
@@ -161,30 +161,30 @@ EOF
 
 @test "use colons in roots-dir path name should fail" {
     local tmpd=$(pwd)
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /foo
 EOF
-    bad_stacker --roots-dir $tmpd/with:colon build
+    bad_stacker --roots-dir $tmpd/with:colon build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 1 ]
     echo $output | grep "forbidden"
 }
 
 @test "use colons in layer name should fail" {
     local tmpd=$(pwd)
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:with:colon:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /foo
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 1 ]
     echo $output | grep "forbidden"
 }
@@ -193,7 +193,7 @@ EOF
     cat > subs.yaml << EOF
     FAVICON: favicon.ico
 EOF
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: tar
@@ -204,7 +204,7 @@ busybox:
         - https://www.cisco.com/favicon.ico
         - ./executable
     run:
-        - cp /stacker/imports/\$FAVICON /\$FAVICON
+        - cp /stacker/imports/${{FAVICON}} ${{FAVICON}}
         - ls -al /stacker
         - cp /stacker/imports/executable /usr/bin/executable
     entrypoint: echo hello world
@@ -270,7 +270,7 @@ EOF
     cat oci/blobs/sha256/$manifest | jq -r '.annotations."io.stackeroci.stacker.stacker_yaml"' | sed '$ d' > stacker_yaml_annotation
 
     # now we need to do --substitute FAVICON=favicon.ico
-    sed -e 's/$FAVICON/favicon.ico/g' stacker.yaml > stacker_after_subs
+    sed -e 's/${{FAVICON}}/favicon.ico/g' stacker.yaml > stacker_after_subs
 
     diff -U5 stacker_yaml_annotation stacker_after_subs
 
@@ -306,13 +306,13 @@ EOF
 }
 
 @test "commas in substitute flags ok" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /foo
 EOF
-    stacker build --substitute "a=b,c"
+    stacker build --substitute "a=b,c" --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -10,11 +10,11 @@ function teardown() {
 
 @test "all container contents must be accounted for" {
   skip_slow_test
-  cat > stacker.yaml <<EOF
+  cat > stacker.yaml <<"EOF"
 bom-parent:
     from:
         type: oci
-        url: $CENTOS_OCI
+        url: ${{CENTOS_OCI}}
     bom:
       generate: true
       namespace: "https://test.io/artifacts"
@@ -55,7 +55,7 @@ bom-parent:
       org.opencontainers.image.vendor: bom-test
       org.opencontainers.image.licenses: MIT
 EOF
-    run stacker build
+    run stacker build --substitute CENTOS_OCI=${CENTOS_OCI}
     [ "$status" -ne 0 ]
     # a full inventory for this image
     [ -f .stacker/artifacts/bom-parent/inventory.json ]
@@ -69,11 +69,11 @@ EOF
 
 @test "bom tool should work inside run" {
   skip_slow_test
-  cat > stacker.yaml <<EOF
+  cat > stacker.yaml <<"EOF"
 bom-parent:
     from:
         type: oci
-        url: $CENTOS_OCI
+        url: ${{CENTOS_OCI}}
     bom:
       generate: true
       namespace: "https://test.io/artifacts"
@@ -132,7 +132,7 @@ bom-child:
       org.opencontainers.image.vendor: bom-test
       org.opencontainers.image.licenses: MIT
 EOF
-    stacker build
+    stacker build --substitute CENTOS_OCI=${CENTOS_OCI}
     [ -f .stacker/artifacts/bom-parent/installed-packages.json ]
     # a full inventory for this image
     [ -f .stacker/artifacts/bom-parent/inventory.json ]
@@ -144,7 +144,7 @@ EOF
     [ -f .stacker/artifacts/bom-child/bom-child.json ]
     if [ -n "${ZOT_HOST}:${ZOT_PORT}" ]; then
       zot_setup
-      stacker publish --skip-tls --url docker://${ZOT_HOST}:${ZOT_PORT} --tag latest
+      stacker publish --skip-tls --url docker://${ZOT_HOST}:${ZOT_PORT} --tag latest --substitute CENTOS_OCI=${CENTOS_OCI}
       refs=$(regctl artifact tree ${ZOT_HOST}:${ZOT_PORT}/bom-parent:latest --format "{{json .}}" | jq '.referrer | length')
       [ $refs -eq 2 ]
       refs=$(regctl artifact get --subject ${ZOT_HOST}:${ZOT_PORT}/bom-parent:latest --filter-artifact-type "application/spdx+json" | jq '.SPDXID')
@@ -159,11 +159,11 @@ EOF
 }
 
 @test "bom for alpine-based image" {
-  cat > stacker.yaml <<EOF
+  cat > stacker.yaml <<"EOF"
 bom-alpine:
   from:
     type: oci
-    url: $ALPINE_OCI
+    url: ${{ALPINE_OCI}}
   bom:
     generate: true
     namespace: "https://test.io/artifacts"
@@ -186,7 +186,7 @@ bom-alpine:
     # cleanup
     rm -f /etc/alpine-release /etc/apk/arch /etc/apk/repositories /etc/apk/world /etc/issue /etc/os-release /etc/secfixes.d/alpine /lib/apk/db/installed /lib/apk/db/lock /lib/apk/db/scripts.tar /lib/apk/db/triggers
 EOF
-    stacker build
+    stacker build --substitute ALPINE_OCI=${ALPINE_OCI}
     [ -f .stacker/artifacts/bom-alpine/installed-packages.json ]
     # a full inventory for this image
     [ -f .stacker/artifacts/bom-alpine/inventory.json ]
@@ -194,7 +194,7 @@ EOF
     [ -f .stacker/artifacts/bom-alpine/bom-alpine.json ]
     if [ -n "${ZOT_HOST}:${ZOT_PORT}" ]; then
       zot_setup
-      stacker publish --skip-tls --url docker://${ZOT_HOST}:${ZOT_PORT} --tag latest
+      stacker publish --skip-tls --url docker://${ZOT_HOST}:${ZOT_PORT} --tag latest --substitute ALPINE_OCI=${ALPINE_OCI}
       refs=$(regctl artifact tree ${ZOT_HOST}:${ZOT_PORT}/bom-alpine:latest --format "{{json .}}" | jq '.referrer | length')
       [ $refs -eq 2 ]
       refs=$(regctl artifact get --subject ${ZOT_HOST}:${ZOT_PORT}/bom-alpine:latest --filter-artifact-type "application/spdx+json" | jq '.SPDXID')

--- a/test/broken-link.bats
+++ b/test/broken-link.bats
@@ -10,18 +10,18 @@ function teardown() {
 }
 
 @test "importing broken symlink is ok" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 broken_link:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - dir
     run: cp -a /stacker/imports/dir/testln /testln
 EOF
     mkdir -p dir
     ln -s broken dir/testln
-	stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:broken_link dest
     [ "$status" -eq 0 ]
 

--- a/test/build-only.bats
+++ b/test/build-only.bats
@@ -10,14 +10,14 @@ function teardown() {
 }
 
 @test "build only + missing prereq fails" {
-    cat > prereq.yaml <<EOF
+    cat > prereq.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 config:
     prerequisites:
         - ./prereq.yaml
@@ -27,19 +27,19 @@ child:
         tag: zomg
     run: echo "d2" > /bestgame
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "couldn't resolve some dependencies"
 }
 
 @test "build only + prerequisites work" {
-    cat > prereq.yaml <<EOF
+    cat > prereq.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 config:
     prerequisites:
         - ./prereq.yaml
@@ -49,17 +49,17 @@ child:
         tag: parent
     run: echo "d2" > /bestgame
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:child dest
     [ "$(cat dest/rootfs/bestgame)" == "d2" ]
 }
 
 @test "after build only failure works" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         false
     build_only: true
@@ -70,19 +70,19 @@ child:
     run: |
         touch /child
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     sed 's/false/true/g' -i stacker.yaml
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:child dest
     [ -f dest/rootfs/child ]
 }
 
 @test "build only stacker" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports: https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico
@@ -96,18 +96,18 @@ layer1:
     run:
         - cp /stacker/imports/favicon.ico /favicon2.ico
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:layer1 dest
     [ "$(sha dest/rootfs/favicon.ico)" == "$(sha dest/rootfs/favicon2.ico)" ]
     [ "$(umoci ls --layout ./oci)" == "$(printf "layer1")" ]
 }
 
 @test "stacker grab" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports: https://www.cisco.com/favicon.ico
     run: |
         cp /stacker/imports/favicon.ico /favicon.ico
@@ -121,7 +121,7 @@ layer1:
     run:
         - cp /stacker/imports/favicon.ico /favicon2.ico
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     stacker grab busybox:/favicon.ico
     [ -f favicon.ico ]
     [ "$(sha favicon.ico)" == "$(sha .stacker/imports/busybox/favicon.ico)" ]
@@ -153,7 +153,7 @@ EOF
 one:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /1
 two:

--- a/test/built-type.bats
+++ b/test/built-type.bats
@@ -9,11 +9,11 @@ function teardown() {
 }
 
 @test "built type layers are restored correctly" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /root/parent
         cat /proc/self/mountinfo
@@ -25,7 +25,7 @@ child:
         cat /proc/self/mountinfo
         touch /root/child
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     umoci --log=debug unpack --image oci:parent dest/parent
     [ "$status" -eq 0 ]

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -43,11 +43,11 @@ EOF
 }
 
 @test "built-type layer import caching" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 build-base:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 base:
     from:
         type: built
@@ -58,19 +58,19 @@ base:
         cp /stacker/imports/foo /foo
 EOF
     touch foo
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo "second time" > foo
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:base dest
     [ "$(cat dest/rootfs/foo)" == "second time" ]
 }
 
 @test "import caching" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 import-cache:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - link/foo
     run: cp /stacker/imports/foo/zomg /zomg
@@ -81,20 +81,20 @@ EOF
     echo bar >> tree2/foo/zomg
 
     ln -s tree1 link
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     rm link && ln -s tree2 link
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     rm link
     umoci unpack --image oci:import-cache dest
     [ "$(sha tree2/foo/zomg)" == "$(sha dest/rootfs/zomg)" ]
 }
 
 @test "remove from a dir" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 a:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - foo
     run: |
@@ -103,21 +103,21 @@ EOF
 
     mkdir -p foo
     touch foo/bar
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 0 ]
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 a:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - foo
     run: |
         [ ! -f /stacker/imports/foo/bar ]
 EOF
     rm foo/bar
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "bind rebuilds" {
@@ -164,21 +164,21 @@ EOF
 }
 
 @test "mode change is re-imported" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 mode-test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - executable
     run: cp /stacker/imports/executable /executable
 EOF
     touch executable
     cat stacker.yaml
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     chmod +x executable
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     umoci unpack --image oci:mode-test dest
     [ -x dest/rootfs/executable ]
@@ -200,28 +200,28 @@ EOF
     chmod 755 "$oldbin"
 
     touch foo
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - foo
     run: cp /stacker/imports/foo /foo
 EOF
 
-    run_as "$oldbin" --debug build
-    stacker build
+    run_as "$oldbin" --debug build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "different old cache version is ok" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo '{"version": 1, "cache": "lolnope"}' > .stacker/build.cache
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }

--- a/test/chroot.bats
+++ b/test/chroot.bats
@@ -10,13 +10,13 @@ function teardown() {
 }
 
 @test "chroot goes to a reasonable place" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 thing:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: touch /test
 EOF
-    stacker build
-    echo "[ -f /test ]" | stacker chroot
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
+    echo "[ -f /test ]" | stacker chroot --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -9,12 +9,12 @@ function teardown() {
 }
 
 @test "clean of unpriv overlay works" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     stacker clean
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -14,15 +14,15 @@ function teardown() {
 
     local tmpd=$(pwd)
     echo "tmpd $tmpd"
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
 
     stacker "--oci-dir=$tmpd/args-oci" "--stacker-dir=$tmpd/args-stacker" \
-        "--roots-dir=$tmpd/args-roots" build
+        "--roots-dir=$tmpd/args-roots" build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ -d "$tmpd/args-oci" ]
     [ -d "$tmpd/args-stacker" ]
 }
@@ -33,11 +33,11 @@ EOF
     local tmpd=$(pwd)
     echo "tmpd $tmpd"
     find $tmpd
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
     cat > "$tmpd/config.yaml" <<EOF
 stacker_dir: $tmpd/config-stacker
@@ -45,7 +45,7 @@ oci_dir: $tmpd/config-oci
 rootfs_dir: $tmpd/config-roots
 EOF
 
-    stacker "--config=$tmpd/config.yaml" build
+    stacker "--config=$tmpd/config.yaml" build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     ls
     [ -d "$tmpd/config-oci" ]
     [ -d "$tmpd/config-stacker" ]

--- a/test/dependency-order.bats
+++ b/test/dependency-order.bats
@@ -22,16 +22,16 @@ EOF
 }
 
 @test "imports missing fails and prints" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        tag: $BUSYBOX_OCI
+        tag: ${{BUSYBOX_OCI}}
     imports:
         - stacker://foo/bar
         - stacker://baz/foo
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo "${output}" | grep "couldn't find dependencies for test: stacker://foo/bar, stacker://baz/foo"
 }
 

--- a/test/dirlinks.bats
+++ b/test/dirlinks.bats
@@ -9,11 +9,11 @@ function teardown() {
 }
 
 @test "copy_up on a dirlink renders a dirlink (squashfs)" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         mkdir /dir
         ln -s /dir /link
@@ -24,7 +24,7 @@ child:
     run: |
         touch /link/test
 EOF
-    stacker --storage-type=overlay build --layer-type=squashfs
+    stacker --storage-type=overlay build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[1].digest | cut -f2 -d:)
     layer1=$(cat oci/blobs/sha256/$manifest | jq -r .layers[1].digest | cut -f2 -d:)

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -9,11 +9,11 @@ function teardown() {
 }
 
 @test "entrypoint mess" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 base:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     cmd: foo
 layer1:
     from:
@@ -26,7 +26,7 @@ layer2:
         tag: layer1
     full_command: baz
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     config=$(cat oci/blobs/sha256/$manifest | jq -r .config.digest | cut -f2 -d:)

--- a/test/env.bats
+++ b/test/env.bats
@@ -13,11 +13,11 @@ function teardown() {
     touch .stacker/imports/test/foo
     chmod -R 777 .stacker/imports
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         # make sure that /stacker is readonly
         grep "/stacker" /proc/mounts | grep "[[:space:]]ro[[:space:],]"
@@ -25,15 +25,15 @@ test:
         # make sure stacker deleted the non-import
         [ ! -f /stacker/foo ]
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "two stackers can't run at the same time" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo hello world
 EOF
@@ -43,13 +43,13 @@ EOF
 
     (
         flock 9
-        bad_stacker build
+        bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
         echo "${output}" | grep "couldn't acquire lock"
     ) 9<roots/.lock
 
     (
         flock 9
-        bad_stacker build
+        bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
         echo "${output}" | grep "couldn't acquire lock"
     ) 9<.stacker/.lock
 }

--- a/test/grab.bats
+++ b/test/grab.bats
@@ -11,11 +11,11 @@ function teardown() {
 # do a build and a grab in an empty directory and
 # verify that no unexpected files are created.
 @test "grab has no side-effects" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 layer1:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - myfile.txt
     run: |
@@ -32,7 +32,7 @@ EOF
     expected_sha=$(sha myfile.txt)
 
     cd "$bdir"
-    stacker "--work-dir=$wkdir" build "--stacker-file=$startdir/stacker.yaml"
+    stacker "--work-dir=$wkdir" build "--stacker-file=$startdir/stacker.yaml" --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     dir_is_empty . ||
         test_error "build dir had unexpected files: $_RET_EXTRA"
 

--- a/test/import-http.bats
+++ b/test/import-http.bats
@@ -10,11 +10,11 @@ function setup() {
     # Need to separate layer download from the download of the test file for imports
     # As we want to be able to have network for base image download
     # in img/stacker1.yaml but disconnect the network for test file download
-    cat > img/stacker1.yaml <<EOF
+    cat > img/stacker1.yaml <<"EOF"
 busybox_base:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         ls
 EOF
@@ -42,7 +42,7 @@ function teardown() {
     require_privilege priv
 
     # Build base image
-    stacker build -f img/stacker1.yaml
+    stacker build -f img/stacker1.yaml --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci ls --layout oci
     # First execution creates the cache
     stacker build -f img/stacker2.yaml
@@ -60,7 +60,7 @@ function teardown() {
 
 @test "importing cached file from http url with matching length" {
     # Build base image
-    stacker build -f img/stacker1.yaml
+    stacker build -f img/stacker1.yaml --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci ls --layout oci
     # First execution creates the cache
     stacker build -f img/stacker2.yaml
@@ -74,11 +74,11 @@ function teardown() {
 }
 
 @test "importing to a dest" {
-    cat > img/stacker1.yaml <<EOF
+    cat > img/stacker1.yaml <<"EOF"
 busybox_base:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - path: https://www.cisco.com/favicon.ico
           dest: /dest/icon
@@ -88,7 +88,7 @@ busybox_base:
         [ ! -f /stacker/favicon.ico ]
 EOF
     # Build base image
-    stacker build -f img/stacker1.yaml
+    stacker build -f img/stacker1.yaml --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci ls --layout oci
 }
 

--- a/test/invalid.bats
+++ b/test/invalid.bats
@@ -9,41 +9,41 @@ function teardown() {
 }
 
 @test "bad stacker:// import" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 bad:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - stacker://idontexist/file
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "invalid yaml entry" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 foo:
     notanentry:
         foo: bar
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "missing tag for base layer of type built" {
-    cat > stacker1.yaml <<EOF
+    cat > stacker1.yaml <<"EOF"
 layer1:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
-    cat > stacker2.yaml <<EOF
+    cat > stacker2.yaml <<"EOF"
 config:
     prerequisites:
         - stacker1.yaml
 layer2:
     from:
         type: built
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
-    bad_stacker build -f stacker2.yaml
+    bad_stacker build -f stacker2.yaml --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }

--- a/test/labels.bats
+++ b/test/labels.bats
@@ -9,16 +9,16 @@ function teardown() {
 }
 
 @test "generate_labels generates oci labels" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 label:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     generate_labels: |
         echo -n "rocks" > /stacker/oci-labels/meshuggah
 EOF
 
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     config=$(cat oci/blobs/sha256/$manifest | jq -r .config.digest | cut -f2 -d:)
     [ "$(cat "oci/blobs/sha256/$config" | jq -r .config.Labels.meshuggah)" = "rocks" ]

--- a/test/log.bats
+++ b/test/log.bats
@@ -30,25 +30,25 @@ function teardown() {
 }
 
 @test "--progress works" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
 
-    stacker --progress build
+    stacker --progress build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo "$output" | grep "Copying blob"
 }
 
 @test "no progress when not attached to a terminal" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 EOF
 
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ -z "$(echo "$output" | grep "Copying blob")" ]
 }

--- a/test/multi-arch.bats
+++ b/test/multi-arch.bats
@@ -9,17 +9,17 @@ function teardown() {
 }
 
 @test "multi-arch/os support" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     os: darwin
     arch: arm64
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - https://www.cisco.com/favicon.ico
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     # check OCI image generation
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
@@ -30,15 +30,15 @@ EOF
 }
 
 @test "multi-arch/os bad config fails" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     os:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - https://www.cisco.com/favicon.ico
 EOF
-    bad_stacker build
+    bad_stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     [ "$status" -eq 1 ]
 }

--- a/test/multiple-output-types.bats
+++ b/test/multiple-output-types.bats
@@ -9,15 +9,15 @@ function teardown() {
 }
 
 @test "multiple layer type outputs work" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo meshuggah > /rocks
 EOF
-    stacker build --layer-type tar --layer-type squashfs
+    stacker build --layer-type tar --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     # did the tar output work?
     umoci unpack --image oci:test dest
@@ -32,11 +32,11 @@ EOF
 }
 
 @test "chained multiple layer type outputs work" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo meshuggah > /rocks
 child:
@@ -46,7 +46,7 @@ child:
     run: |
         echo primus > /sucks
 EOF
-    stacker build --layer-type tar --layer-type squashfs
+    stacker build --layer-type tar --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     # did the tar output work?
     umoci unpack --image oci:child dest
@@ -68,11 +68,11 @@ EOF
 }
 
 @test "build-only multiple layer type outputs work" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo meshuggah > /rocks
     build_only: true
@@ -83,7 +83,7 @@ child:
     run: |
         echo primus > /sucks
 EOF
-    stacker build --layer-type tar --layer-type squashfs
+    stacker build --layer-type tar --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     # did the tar output work?
     umoci unpack --image oci:child dest
@@ -105,26 +105,26 @@ EOF
 }
 
 @test "multiple output types cache correctly" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 parent:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo meshuggah > /rocks
 EOF
-    stacker build --layer-type tar --layer-type squashfs
-    stacker build --layer-type tar --layer-type squashfs
+    stacker build --layer-type tar --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
+    stacker build --layer-type tar --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "found cached layer parent"
     echo $output | grep "found cached layer parent-squashfs"
 }
 
 @test "chained built type layers are OK (tar first)" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 one:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 two:
     build_only: true
     from:
@@ -150,7 +150,7 @@ five:
         url: stacker://three/contents.tar
 EOF
 
-    stacker build --layer-type=tar --layer-type=squashfs
+    stacker build --layer-type=tar --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:four four
     [ -f four/rootfs/2 ]
     [ -f four/rootfs/3 ]
@@ -172,11 +172,11 @@ EOF
 }
 
 @test "chained built type layers are OK (squashfs first)" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 one:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
 two:
     build_only: true
     from:
@@ -202,7 +202,7 @@ five:
         url: stacker://three/contents.tar
 EOF
 
-    stacker build --layer-type=squashfs --layer-type=tar
+    stacker build --layer-type=squashfs --layer-type=tar --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     umoci unpack --image oci:four four
     [ -f four/rootfs/2 ]
     [ -f four/rootfs/3 ]

--- a/test/overlay-dirs.bats
+++ b/test/overlay-dirs.bats
@@ -15,11 +15,11 @@ function teardown() {
     touch dir_to_overlay/file2
     touch dir_to_overlay/executable
     chmod +x dir_to_overlay/executable
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<"EOF"
 first:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     overlay_dirs:
         - source: dir_to_overlay
     run: |
@@ -27,7 +27,7 @@ first:
         [ -f /file2 ]
         [ -x /executable ]
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     umoci unpack --image oci:first dest
     [ -f dest/rootfs/file1 ]
@@ -38,11 +38,11 @@ EOF
 @test "import from overlay_dir works" {
     mkdir dir_to_overlay
     touch dir_to_overlay/file
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<"EOF"
 first:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     overlay_dirs:
         - source: dir_to_overlay
     run: |
@@ -55,7 +55,7 @@ second:
     run: |
         [ -f /stacker/imports/file ]
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     umoci unpack --image oci:first dest
     [ -f dest/rootfs/file ]
@@ -64,11 +64,11 @@ EOF
 @test "build binary and import in distroless" {
     mkdir dir_to_overlay
     chmod -R 777 dir_to_overlay
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<"EOF"
 build:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     binds:
         - dir_to_overlay -> /dir_to_overlay
     run: |
@@ -82,7 +82,7 @@ contents:
         - source: dir_to_overlay
           dest: /dir_to_overlay
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     ls dir_to_overlay | grep "binaryfile"
     
     umoci unpack --image oci:contents dest
@@ -94,18 +94,18 @@ EOF
 @test "overlay_dirs dest works" {
     mkdir dir_to_overlay
     touch dir_to_overlay/file
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<"EOF"
 first:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     overlay_dirs:
         - source: dir_to_overlay
           dest: /usr/local
     run: |
         [ -f /usr/local/file ]
 EOF
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     umoci unpack --image oci:first dest
     [ -f dest/rootfs/usr/local/file ]
@@ -118,11 +118,11 @@ EOF
     touch dir_to_overlay2/file2.txt
     mkdir dir_to_overlay3
     touch dir_to_overlay3/file3.txt
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<"EOF"
 first:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     overlay_dirs:
         - source: dir_to_overlay1
           dest: /usr/local1
@@ -131,15 +131,15 @@ first:
         - source: dir_to_overlay3
           dest: /usr/local3
 EOF
-    stacker build
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "found cached layer first"
     echo "modifying file" > dir_to_overlay1/file1.txt
     echo "modifying file" > dir_to_overlay2/file2.txt
     echo "modifying file" > dir_to_overlay3/file3.txt
     
     NO_DEBUG=1
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "cache miss because content of 3 overlay dirs changed:"
     echo $output | grep "Changed overlay_dir:"
     # without debug should print only 2 dirs
@@ -153,7 +153,7 @@ EOF
     echo "modifying file again" > dir_to_overlay3/file3.txt
 
     NO_DEBUG=0
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "cache miss because content of 3 overlay dirs changed:"
     echo $output | grep "Changed overlay_dir:"
     echo $output | grep "dir_to_overlay1"
@@ -165,7 +165,7 @@ EOF
     result=$(echo $output | grep "and 1 other overlay_dirs. use --debug for complete output" || echo "empty")
     echo $result | grep "empty"
     rm -rf roots
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     echo $output | grep "cache miss because overlay_dir was missing"
 }
 
@@ -174,7 +174,7 @@ EOF
     touch dir_to_overlay/file
     touch dir_to_overlay/file2
     chown 1234:1234 dir_to_overlay/file
-    cat > stacker.yaml << EOF
+    cat > stacker.yaml <<EOF
 first:
     from:
         type: oci

--- a/test/squashfs.bats
+++ b/test/squashfs.bats
@@ -14,11 +14,11 @@ function teardown() {
 }
 
 @test "squashfs + derivative build only layers" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 build:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     build_only: true
 importer:
     from:
@@ -27,21 +27,21 @@ importer:
     run: |
         echo hello world
 EOF
-    stacker build --layer-type squashfs
+    stacker build --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "squashfs mutate /usr/bin" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox1:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /usr/bin/foo
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox2:
     from:
         type: oci
@@ -49,19 +49,19 @@ busybox2:
     run: |
         ls /usr/bin | grep foo
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "squashfs import support" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox1:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /1
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
     mv oci oci-import
 
     cat > stacker.yaml <<EOF
@@ -72,20 +72,20 @@ busybox2:
     run: |
         [ -f /1 ]
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "squashfs layer support (overlay)" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         touch /1
 EOF
 
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     layer0=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
@@ -101,17 +101,17 @@ EOF
 }
 
 @test "squashfs file whiteouts (overlay)" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 busybox:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         rm -rf /etc/selinux
         rm -f /usr/bin/ls
 EOF
 
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     layer0=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
@@ -133,22 +133,22 @@ EOF
 }
 
 @test "squashfs + build only layers" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 build:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     build_only: true
 importer:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     imports:
         - stacker://build/bin/ls
     run: |
         /stacker/imports/ls
 EOF
-    stacker build --layer-type squashfs
+    stacker build --layer-type squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }
 
 @test "built type with squashfs works" {
@@ -212,7 +212,7 @@ myroot:
   run: |
     echo "foo bar" > /message
 EOF
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 
     manifest=$(cat oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
     layer0=$(cat oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)

--- a/test/tmpfs.bats
+++ b/test/tmpfs.bats
@@ -9,16 +9,16 @@ function teardown() {
 }
 
 @test "stacker works in a tmpfs" {
-    cat > stacker.yaml <<EOF
+    cat > stacker.yaml <<"EOF"
 test:
     from:
         type: oci
-        url: $BUSYBOX_OCI
+        url: ${{BUSYBOX_OCI}}
     run: |
         echo hello world
 EOF
 
     mkdir -p roots
     mount -t tmpfs -o size=1G tmpfs roots
-    stacker build
+    stacker build --substitute BUSYBOX_OCI=${BUSYBOX_OCI}
 }


### PR DESCRIPTION
**What type of PR is this?**

This is a breaking change to the substitution syntax, which was bad and should be made good.

**What does this PR do / Why do we need it**:

This makes it an error to have placeholders that are valid shell like `$PATH` or `${PATH}` if you have provided a substitution for `PATH` to stacker via `--substitute PATH=why:oh:why`.

Those placeholders are too easy to confuse with a valid shell variable, and stacker can't tell if you intended to provide a value for them but typoed it - and you can't tell by looking at it if it is intended to be a stacker sub or just a shell var.

So they are bad and should be made good by becoming fatal errors.

The documented behavior in docs was not tested fully, and was in fact wrong. Now it's right.

This change is confined to one function that has go unit tests, so I just updated those and the one place where our tests were using `$PLAIN` syntax.

**Will this break upgrades or downgrades?**

Possibly. If people were doing confusing things like `--substitute PATH=ouch`, then their builds will fail with a helpful message about how to fix it.

**Does this PR introduce any user-facing change?**:

```release-note
Substitution placeholders in stacker files with no braces or single braces are no longer supported, and an error will be printed to explain how to replace them. 

all valid shell variables with no braces or single braces are still fine, the change is that now if you provide a substitution `--substitute FOO=val`, then use `$FOO` or `${FOO}` in your stacker file, that will be a fatal error. You must use `${{FOO}}` instead to have stacker replace it with the provided substitution.
```

An example of the new error output is:
```
2024/02/27 16:36:03 error "A=B" was provided as a substitution and unsupported placeholder "${A}" was found. Replace "${A}" with "${{A}}" to use the substitution.
 isStacker=&{}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
