### PR TITLE
add stacker version as annotation to images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ BUILD_TAGS = exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containe
 
 STACKER_OPTS=--oci-dir=$(BUILD_D)/oci --roots-dir=$(BUILD_D)/roots --stacker-dir=$(BUILD_D)/stacker --storage-type=overlay
 
-build_stacker = go build $1 -tags "$(BUILD_TAGS) $2" -ldflags "-X main.version=$(VERSION_FULL) -X main.lxc_version=$(LXC_VERSION) $3" -o $4 ./cmd/stacker
+VERSION_LDFLAGS=-X stackerbuild.io/stacker/pkg/lib.StackerVersion=$(VERSION_FULL) -X stackerbuild.io/stacker/pkg/lib.LXCVersion=$(LXC_VERSION)
+build_stacker = go build $1 -tags "$(BUILD_TAGS) $2" -ldflags "$(VERSION_LDFLAGS) $3" -o $4 ./cmd/stacker
 
 # See doc/hacking.md for how to use a local oci or docker repository.
 STACKER_DOCKER_BASE?=docker://ghcr.io/project-stacker/

--- a/cmd/stacker/main.go
+++ b/cmd/stacker/main.go
@@ -17,14 +17,13 @@ import (
 	"golang.org/x/term"
 	"gopkg.in/yaml.v2"
 	"stackerbuild.io/stacker/pkg/container"
+	"stackerbuild.io/stacker/pkg/lib"
 	stackerlog "stackerbuild.io/stacker/pkg/log"
 	"stackerbuild.io/stacker/pkg/types"
 )
 
 var (
-	config      types.StackerConfig
-	version     = ""
-	lxc_version = ""
+	config types.StackerConfig
 )
 
 func shouldShowProgress(ctx *cli.Context) bool {
@@ -94,7 +93,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "stacker"
 	app.Usage = "stacker builds OCI images"
-	app.Version = fmt.Sprintf("stacker %s liblxc %s", version, lxc_version)
+	app.Version = fmt.Sprintf("stacker %s liblxc %s", lib.StackerVersion, lib.LXCVersion)
 
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {
@@ -309,7 +308,7 @@ func main() {
 		}
 
 		stackerlog.FilterNonStackerLogs(handler, logLevel)
-		stackerlog.Debugf("stacker version %s", version)
+		stackerlog.Debugf("stacker version %s", lib.StackerVersion)
 
 		if !ctx.Bool("internal-userns") && !shouldSkipInternalUserns(ctx) && len(os.Args) > 1 {
 			binary, err := os.Readlink("/proc/self/exe")

--- a/pkg/lib/version.go
+++ b/pkg/lib/version.go
@@ -1,0 +1,6 @@
+package lib
+
+var (
+	StackerVersion = ""
+	LXCVersion     = ""
+)

--- a/pkg/stacker/api.go
+++ b/pkg/stacker/api.go
@@ -5,6 +5,7 @@ import "fmt"
 const (
 	GitVersionAnnotation      = "%s.stacker.git_version"
 	StackerContentsAnnotation = "%s.stacker.stacker_yaml"
+	StackerVersionAnnotation  = "%s.stacker.stacker_version"
 )
 
 func getGitVersionAnnotation(namespace string) string {
@@ -13,4 +14,8 @@ func getGitVersionAnnotation(namespace string) string {
 
 func getStackerContentsAnnotation(namespace string) string {
 	return fmt.Sprintf(StackerContentsAnnotation, namespace)
+}
+
+func getStackerVersionAnnotation(namespace string) string {
+	return fmt.Sprintf(StackerVersionAnnotation, namespace)
 }

--- a/pkg/stacker/build.go
+++ b/pkg/stacker/build.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	"stackerbuild.io/stacker/pkg/container"
+	"stackerbuild.io/stacker/pkg/lib"
 	"stackerbuild.io/stacker/pkg/log"
 	"stackerbuild.io/stacker/pkg/test"
 	"stackerbuild.io/stacker/pkg/types"
@@ -281,6 +282,7 @@ func (b *Builder) updateOCIConfigForOutput(sf *types.Stackerfile, s types.Storag
 	}
 
 	annotations[getStackerContentsAnnotation(opts.AnnotationsNamespace)] = sf.AfterSubstitutions
+	annotations[getStackerVersionAnnotation(opts.AnnotationsNamespace)] = lib.StackerVersion
 
 	history := ispec.History{
 		EmptyLayer: true, // this is only the history for imageConfig edit


### PR DESCRIPTION
It can be useful to know which version of stacker created an image. Let's put it in there.

Moves some things around to avoid multiple definitions & import loops.
