### PR TITLE
fix: allow bom build and verification for `build_only` layers

### DIFF
--- a/pkg/stacker/bom.go
+++ b/pkg/stacker/bom.go
@@ -3,10 +3,12 @@ package stacker
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"stackerbuild.io/stacker/pkg/container"
 	"stackerbuild.io/stacker/pkg/log"
 	"stackerbuild.io/stacker/pkg/types"
@@ -108,6 +110,11 @@ func ImportArtifacts(sc types.StackerConfig, src types.ImageSource, name string)
 	if src.Type == types.BuiltLayer {
 		// if a bom is available, add it here so it can be merged
 		srcpath := path.Join(sc.StackerDir, "artifacts", src.Tag, fmt.Sprintf("%s.json", src.Tag))
+
+		_, err := os.Lstat(srcpath)
+		if err != nil && errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
 
 		dstfp, err := os.CreateTemp(path.Join(sc.StackerDir, "artifacts", name), fmt.Sprintf("%s-*.json", name))
 		if err != nil {

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -305,3 +305,63 @@ EOF
     fi
     stacker clean
 }
+
+@test "all container contents must be accounted for even for build_only layers" {
+  skip_slow_test
+  cat > stacker.yaml <<"EOF"
+bom-parent:
+    build_only: true
+    from:
+        type: oci
+        url: ${{CENTOS_OCI}}
+    bom:
+      generate: true
+      namespace: "https://test.io/artifacts"
+      packages:
+      - name: pkg1
+        version: 1.0.0
+        license: Apache-2.0
+        paths: [/pkg1]
+      - name: pkg2
+        version: 1.0.0
+        license: Apache-2.0
+        paths: [/pkg2]
+    run: |
+      # discover installed pkgs
+      /stacker/bin/stacker bom discover
+      # our own custom packages
+      mkdir -p /pkg1
+      touch /pkg1/file
+      mkdir -p /pkg2
+      touch /pkg2/file
+      # should cause build to fail!
+      mkdir -p /orphan-without-a-package
+      touch /orphan-without-a-package/file
+      # cleanup
+      rm -rf /var/lib/alternatives /tmp/* \
+        /etc/passwd- /etc/group- /etc/shadow- /etc/gshadow- \
+        /etc/sysconfig/network /etc/nsswitch.conf.bak \
+        /etc/rpm/macros.image-language-conf /var/lib/rpm/.dbenv.lock \
+        /var/lib/rpm/Enhancename /var/lib/rpm/Filetriggername \
+        /var/lib/rpm/Recommendname /var/lib/rpm/Suggestname \
+        /var/lib/rpm/Supplementname /var/lib/rpm/Transfiletriggername \
+        /var/log/anaconda \
+        /etc/sysconfig/anaconda /etc/sysconfig/network-scripts/ifcfg-* \
+        /etc/sysconfig/sshd-permitrootlogin /root/anaconda-* /root/original-* /run/nologin \
+        /var/lib/rpm/.rpm.lock /etc/.pwd.lock /etc/BUILDTIME
+    annotations:
+      org.opencontainers.image.authors: bom-test
+      org.opencontainers.image.vendor: bom-test
+      org.opencontainers.image.licenses: MIT
+EOF
+    run stacker build --substitute CENTOS_OCI=${CENTOS_OCI}
+    [ "$status" -ne 0 ]
+    # a full inventory for this image
+    [ -f .stacker/artifacts/bom-parent/inventory.json ]
+    # sbom for this image shouldn't be generated
+    [ ! -a .stacker/artifacts/bom-parent/first.json ]
+    # building a second time also fails due to missed cache
+    run stacker build
+    [ "$status" -ne 0 ]
+    stacker clean
+}

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -365,3 +365,89 @@ EOF
     [ "$status" -ne 0 ]
     stacker clean
 }
+
+@test "skip bom generation for built layer" {
+  skip_slow_test
+  cat > stacker.yaml <<"EOF"
+first:
+    from:
+        type: oci
+        url: ${{CENTOS_OCI}}
+    bom:
+      generate: true
+      namespace: "https://test.io/artifacts"
+      packages:
+      - name: pkg1
+        version: 1.0.0
+        license: Apache-2.0
+        paths: [/pkg1]
+      - name: pkg2
+        version: 1.0.0
+        license: Apache-2.0
+        paths: [/pkg2]
+    run: |
+      # our own custom packages
+      mkdir -p /pkg1
+      touch /pkg1/file
+      mkdir -p /pkg2
+      touch /pkg2/file
+
+second:
+  from:
+    type: built
+    tag: first
+  bom:
+    generate: true
+    namespace: "https://test.io/artifacts"
+    packages:
+    - name: pkg1
+      version: 1.0.0
+      license: Apache-2.0
+      paths: [/pkg1]
+    - name: pkg2
+      version: 1.0.0
+      license: Apache-2.0
+      paths: [/pkg2]
+    - name: pkg3
+      version: 1.0.0
+      license: Apache-2.0
+      paths: [/pkg3]
+  run: |
+    # discover installed pkgs
+    /stacker/bin/stacker bom discover
+    # our own custom packages
+    mkdir -p /pkg3
+    touch /pkg3/file
+    # cleanup
+    rm -rf /var/lib/alternatives /tmp/* \
+      /etc/passwd- /etc/group- /etc/shadow- /etc/gshadow- \
+      /etc/sysconfig/network /etc/nsswitch.conf.bak \
+      /etc/rpm/macros.image-language-conf /var/lib/rpm/.dbenv.lock \
+      /var/lib/rpm/Enhancename /var/lib/rpm/Filetriggername \
+      /var/lib/rpm/Recommendname /var/lib/rpm/Suggestname \
+      /var/lib/rpm/Supplementname /var/lib/rpm/Transfiletriggername \
+      /var/log/anaconda \
+      /etc/sysconfig/anaconda /etc/sysconfig/network-scripts/ifcfg-* \
+      /etc/sysconfig/sshd-permitrootlogin /root/anaconda-* /root/original-* /run/nologin \
+      /var/lib/rpm/.rpm.lock /etc/.pwd.lock /etc/BUILDTIME
+  annotations:
+      org.opencontainers.image.authors: bom-test
+      org.opencontainers.image.vendor: bom-test
+      org.opencontainers.image.licenses: MIT
+EOF
+    stacker build --substitute CENTOS_OCI=${CENTOS_OCI}
+    # a full inventory for this image
+    [ -f .stacker/artifacts/second/inventory.json ]
+    # sbom for this image
+    [ -f .stacker/artifacts/second/second.json ]
+    if [ -n "${ZOT_HOST}:${ZOT_PORT}" ]; then
+      zot_setup
+      stacker publish --skip-tls --url docker://${ZOT_HOST}:${ZOT_PORT} --tag latest --substitute CENTOS_OCI=${CENTOS_OCI}
+      refs=$(regctl artifact tree ${ZOT_HOST}:${ZOT_PORT}/second:latest --format "{{json .}}" | jq '.referrer | length')
+      [ $refs -eq 2 ]
+      refs=$(regctl artifact get --subject ${ZOT_HOST}:${ZOT_PORT}/second:latest --filter-artifact-type "application/spdx+json" | jq '.SPDXID')
+      [ $refs == \"SPDXRef-DOCUMENT\" ]
+      zot_teardown
+    fi
+    stacker clean
+}


### PR DESCRIPTION
From our experience, package information may be removed in such layers making it much harder to discover and auto-construct BOMs.

So allow this for `build_only` layers also.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
