### PR TITLE
fix: avoid max read size reached error when cmp imported files

### DIFF
--- a/pkg/stacker/import.go
+++ b/pkg/stacker/import.go
@@ -1,6 +1,7 @@
 package stacker
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -59,7 +60,11 @@ func filesDiffer(p1 string, info1 os.FileInfo, p2 string, info2 os.FileInfo) (bo
 	}
 	defer f2.Close()
 
-	eq, err := equalfile.New(nil, equalfile.Options{}).CompareReader(f1, f2)
+	// use limited reader to prevent the default cap of 10**10 max file size
+	limf1R := io.LimitReader(f1, info1.Size())
+	limf2R := io.LimitReader(f2, info2.Size())
+
+	eq, err := equalfile.New(nil, equalfile.Options{}).CompareReader(limf1R, limf2R)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

#617 

**What does this PR do / Why do we need it**:

when dealing with large files in imports (> 10**10 bytes) then equalfile fails.
this PR uses io.LimitedReader to avoid the error path.



**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
