### PR TITLE
test: fix missing pkgs in bom

### DIFF
--- a/test/bom.bats
+++ b/test/bom.bats
@@ -386,11 +386,25 @@ first:
         license: Apache-2.0
         paths: [/pkg2]
     run: |
+      # discover installed pkgs
+      /stacker/bin/stacker bom discover
       # our own custom packages
       mkdir -p /pkg1
       touch /pkg1/file
       mkdir -p /pkg2
       touch /pkg2/file
+      # cleanup
+      rm -rf /var/lib/alternatives /tmp/* \
+        /etc/passwd- /etc/group- /etc/shadow- /etc/gshadow- \
+        /etc/sysconfig/network /etc/nsswitch.conf.bak \
+        /etc/rpm/macros.image-language-conf /var/lib/rpm/.dbenv.lock \
+        /var/lib/rpm/Enhancename /var/lib/rpm/Filetriggername \
+        /var/lib/rpm/Recommendname /var/lib/rpm/Suggestname \
+        /var/lib/rpm/Supplementname /var/lib/rpm/Transfiletriggername \
+        /var/log/anaconda \
+        /etc/sysconfig/anaconda /etc/sysconfig/network-scripts/ifcfg-* \
+        /etc/sysconfig/sshd-permitrootlogin /root/anaconda-* /root/original-* /run/nologin \
+        /var/lib/rpm/.rpm.lock /etc/.pwd.lock /etc/BUILDTIME
     annotations:
       org.opencontainers.image.authors: bom-test
       org.opencontainers.image.vendor: bom-test


### PR DESCRIPTION
In the nightly extended bom tests, we use a centos base layer and hence discovery must be performed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
