### PR TITLE
fix: check bind source file/dir exists

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -65,6 +65,9 @@ func New(sc types.StackerConfig, name string) (*Container, error) {
 func (c *Container) BindMount(source string, dest string, extraOpts string) error {
 	createOpt := "create=dir"
 	stat, err := os.Stat(source)
+	if os.IsNotExist(err) {
+		return errors.Errorf("bind mount source %q does not exist, refusing bind mount: %s", source, err)
+	}
 	if err == nil && !stat.IsDir() {
 		createOpt = "create=file"
 	}

--- a/pkg/stacker/build.go
+++ b/pkg/stacker/build.go
@@ -820,9 +820,10 @@ func SetupLayerConfig(config types.StackerConfig, c *container.Container, l type
 	}
 
 	for _, bind := range l.Binds {
+		log.Debugf("bind mounting %q into container at %q", bind.Source, bind.Dest)
 		err = c.BindMount(bind.Source, bind.Dest, "")
 		if err != nil {
-			return err
+			return errors.Errorf("failed to bind mount %q at %q: %s", bind.Source, bind.Dest, err)
 		}
 	}
 


### PR DESCRIPTION
Stacker does not check if a bind mount source exists and if the source is a directory then the container crashes with a stack trace that does not indicate that the missing source dir is the issue.

Check if the source exists and return an error indicating the source is missing instead of the container stack trace.


**What type of PR is this?**


bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:

```
$ mkdir test-binds && cd test-binds
$ cat > stacker.yaml <<EOF
hello-binds:
  from:
    type: docker
    url: docker://zothub.io/tools/busybox:stable
  binds:
    - mydir -> /mydir
  run: |
    mkdir -p /hello-stacker-app
    echo 'echo "Hello Stacker!"' > /hello-stacker-app/hello.sh
EOF
$ stacker build -f stacker.yaml
```

**Testing done on this change**:

Above test returns an error indicating that the source directory in binds is missing.

**Automation added to e2e**:

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
