### PR TITLE
build: improve errors for --oci-dir cases

### DIFF
--- a/pkg/lib/dir.go
+++ b/pkg/lib/dir.go
@@ -10,16 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func IsSymlink(p string) bool {
-	fi, err := os.Lstat(p)
-	if err != nil {
-		// Some people can't be helped
-		return false
-	}
-
-	return fi.Mode()&os.ModeSymlink != 0
-}
-
 // DirCopy copies a whole directory recursively
 func DirCopy(dest string, source string) error {
 

--- a/pkg/lib/dir_test.go
+++ b/pkg/lib/dir_test.go
@@ -19,7 +19,7 @@ func TestDir(t *testing.T) {
 		_, err = src.Write([]byte("hello world!"))
 		So(err, ShouldBeNil)
 
-		ok := lib.IsSymlink(src.Name())
+		ok, _ := lib.IsSymlink(src.Name())
 		So(ok, ShouldBeFalse)
 	})
 

--- a/pkg/lib/file.go
+++ b/pkg/lib/file.go
@@ -111,3 +111,26 @@ func FindFiles(base, pattern string) ([]string, error) {
 
 	return paths, err
 }
+
+func IsSymlink(path string) (bool, error) {
+	statInfo, err := os.Lstat(path)
+	if err != nil {
+		return false, err
+	}
+	return (statInfo.Mode() & os.ModeSymlink) != 0, nil
+}
+
+func PathExists(path string) bool {
+	statInfo, err := os.Stat(path)
+	if statInfo == nil {
+		isLink, err := IsSymlink(path)
+		if err != nil {
+			return false
+		}
+		return isLink
+	}
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/pkg/overlay/pack.go
+++ b/pkg/overlay/pack.go
@@ -151,7 +151,7 @@ func ConvertAndOutput(config types.StackerConfig, tag, name string, layerType ty
 
 		// slight hack, but this is much faster than a cp, and the
 		// layers are the same, just in different formats
-		if !PathExists(overlayPath(config.RootFSDir, desc.Digest)) {
+		if !lib.PathExists(overlayPath(config.RootFSDir, desc.Digest)) {
 			err = os.Symlink(overlayPath(config.RootFSDir, theLayer.Digest), overlayPath(config.RootFSDir, desc.Digest))
 			if err != nil {
 				return errors.Wrapf(err, "failed to create squashfs symlink")
@@ -167,29 +167,6 @@ func ConvertAndOutput(config types.StackerConfig, tag, name string, layerType ty
 	}
 
 	return nil
-}
-
-func IsSymlink(path string) (bool, error) {
-	statInfo, err := os.Lstat(path)
-	if err != nil {
-		return false, err
-	}
-	return (statInfo.Mode() & os.ModeSymlink) != 0, nil
-}
-
-func PathExists(path string) bool {
-	statInfo, err := os.Stat(path)
-	if statInfo == nil {
-		isLink, err := IsSymlink(path)
-		if err != nil {
-			return false
-		}
-		return isLink
-	}
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-	return true
 }
 
 func lookupManifestInDir(dir, name string) (ispec.Manifest, error) {
@@ -374,7 +351,7 @@ func stripOverlayAttrsUnder(dirPath string) error {
 				return err
 			}
 			p := filepath.Join(dirPath, path)
-			if lib.IsSymlink(p) {
+			if isSymlink, _ := lib.IsSymlink(p); isSymlink {
 				// user.* xattrs "can not" exist on symlinks
 				return nil
 			}


### PR DESCRIPTION
If the argument to oci-dir exists but is empty, we currently get a confusing error about it not being a layout. Other cases could be better explained while we're at it too.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
