### PR TITLE
ci: fix sync image sources

### DIFF
--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -29,7 +29,7 @@ jobs:
           for n in ubuntu:latest alpine:edge alpine:3.19 centos:latest busybox:latest; do
             dest="ghcr.io/${{ github.repository_owner }}/$n"
             docker trust inspect "$n"
-            docker pull $n
+            docker pull public.ecr.aws/docker/library/$n
             docker tag $n "$dest"
             docker push $dest
           done


### PR DESCRIPTION
We periodically update our private container image copies. Point to public.ecr.aws/docker/library/ as source.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
