### PR TITLE
feat: add ability to override platform OS

### DIFF
--- a/pkg/lib/image.go
+++ b/pkg/lib/image.go
@@ -59,6 +59,8 @@ type ImageCopyOpts struct {
 	DestSkipTLS       bool
 	Progress          io.Writer
 	Context           context.Context
+	OverrideOS        string
+	OverrideArch      string
 }
 
 func ImageCopy(opts ImageCopyOpts) error {
@@ -90,7 +92,10 @@ func ImageCopy(opts ImageCopyOpts) error {
 		RemoveSignatures: true,
 	}
 
-	args.SourceCtx = &types.SystemContext{}
+	args.SourceCtx = &types.SystemContext{
+		ArchitectureChoice: opts.OverrideArch,
+		OSChoice:           opts.OverrideOS,
+	}
 
 	if opts.SrcSkipTLS {
 		args.SourceCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
@@ -104,7 +109,10 @@ func ImageCopy(opts ImageCopyOpts) error {
 		}
 	}
 
-	args.DestinationCtx = &types.SystemContext{}
+	args.DestinationCtx = &types.SystemContext{
+		ArchitectureChoice: opts.OverrideArch,
+		OSChoice:           opts.OverrideOS,
+	}
 
 	if opts.DestSkipTLS {
 		args.DestinationCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue


### PR DESCRIPTION
Currently, stacker is bound to the host platform for all its operations. This PR allows for build a container image different from the host platform by overriding the platform OS.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
