### PR TITLE
Add tests to check & document behavior of various ways to handle secrets in builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,14 @@ $(SKOPEO):
 	rm -rf $$tmpdir;
 
 $(BATS):
-	@set -e; rm -rf bats-core; \
-	git clone -b $(BATS_VERSION) https://github.com/bats-core/bats-core.git; \
-	cd bats-core; ./install.sh $(TOOLS_D); cd ..; \
-	rm -rf bats-core
+	mkdir -p $(TOOLS_D)/bin
+	git clone -b $(BATS_VERSION) https://github.com/bats-core/bats-core.git
+	cd bats-core; ./install.sh $(TOOLS_D) ; rm -rf bats-core
+	mkdir -p $(TOP_LEVEL)/test/test_helper
+	git clone --depth 1 https://github.com/bats-core/bats-support $(TOP_LEVEL)/test/test_helper/bats-support
+	git clone --depth 1 https://github.com/bats-core/bats-assert $(TOP_LEVEL)/test/test_helper/bats-assert
+	git clone --depth 1 https://github.com/bats-core/bats-file $(TOP_LEVEL)/test/test_helper/bats-file
+
 
 $(UMOCI):
 	mkdir -p ${GOPATH}/src/github.com/opencontainers/
@@ -227,5 +231,6 @@ vendorup:
 .PHONY: clean
 clean:
 	-unshare -Urm rm -rf stacker stacker-dynamic .build
-	-rm -r ./test/centos ./test/ubuntu
+	-rm -rf ./test/centos ./test/ubuntu ./test/busybox ./test/alpine ./test/test_helper
 	-make -C cmd/stacker/lxc-wrapper clean
+	-rm -rf $(TOOLS_D)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,3 +1,7 @@
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/bats-file/load'
+
 function run_git {
     sudo -u $SUDO_USER git "$@"
 }

--- a/test/hiding-creds.bats
+++ b/test/hiding-creds.bats
@@ -1,0 +1,77 @@
+load helpers
+
+function setup() {
+    stacker_setup
+
+}
+
+function teardown() {
+    cleanup
+}
+
+@test "secrets loaded via imports should not be in output image" {
+
+    cat > stacker.yaml <<"EOF"
+build-with-secrets:
+  from:
+    type: oci
+    url: ${{BUSYBOX_OCI}}
+  imports:
+    - creds
+  run: |
+    source /stacker/imports/creds
+    echo "pass creds via imported files like $creds"
+    echo "don't pass creds on the command line like ${{SUBCRED}}."
+    # also don't do
+    # echo $creds > /ohno
+EOF
+
+    filecred=$(uuidgen)
+    subcred=$(uuidgen)
+
+    cat >creds <<EOF
+export creds=street,hoops,beach,$filecred
+EOF
+
+    stacker --debug build --substitute SUBCRED=$subcred --substitute BUSYBOX_OCI=$BUSYBOX_OCI
+
+    # subcred should be in a manifest:
+    run zgrep $subcred oci/blobs/sha256/*
+    assert_success
+
+    # filecred should not be in the image:
+    run zgrep $filecred oci/blobs/sha256/*
+    assert_failure
+
+}
+
+
+@test "secrets loaded via imports but saved to file WILL leak" {
+
+    cat > stacker.yaml <<"EOF"
+build-with-secrets:
+  from:
+    type: oci
+    url: ${{BUSYBOX_OCI}}
+  imports:
+    - creds
+  run: |
+    source /stacker/imports/creds
+    echo "pass creds via imported files like $creds"
+    # but do not do this:
+    echo $creds > /ohno
+EOF
+
+    filecred=$(uuidgen)
+
+    cat >creds <<EOF
+export creds=street,hoops,beach,$filecred
+EOF
+
+    stacker --debug build --substitute BUSYBOX_OCI=$BUSYBOX_OCI
+
+    # filecred will sadly be in a manifest:
+    run zgrep $filecred oci/blobs/sha256/*
+    assert_success
+
+}


### PR DESCRIPTION
Add a test file to show that --substitute is not a good way to pass secrets, and to ensure that we notice if we break the currently preferred way, using an import file.

Also adds some bats helpers which make test writing nicer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
