### PR TITLE
fix: build-deps for 24.04 don't need ppa anymore

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -53,11 +53,6 @@ installdeps_ubuntu() {
             sudo add-apt-repository -y ppa:project-machine/squashfuse
             ;;
         24.04)
-            # lp:2080069
-            # temporarily add puzzleos/dev to pickup lxc-dev package which
-            # provides static liblxc.a
-            sudo add-apt-repository -y ppa:puzzleos/dev
-
             # allow array to expand again
             #shellcheck disable=2206
             PKGS=( ${PKGS[*]} libsystemd-dev )


### PR DESCRIPTION
It looks like newer lxc release in Noble no longer needs the lxc ppa; it can build stacker-dynamic/stacker static without the package which currently conflicts with the Noble lxc package

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
