### PR TITLE
Chore/GitHub migrate to new node version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,7 +123,7 @@ jobs:
         run: |
           make publish-stacker-bin
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ (matrix.privilege-level == 'priv') }}
         with:
           # if there is more than 1 go-version, we would need to account for that here.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,7 +130,7 @@ jobs:
           name: stacker-${{ matrix.platform }}
           path: stacker-${{ matrix.platform }}
           if-no-files-found: error
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: restore-build
         with:
           path: stacker-${{ matrix.platform }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.platform == 'linux-amd64' && 'ubuntu-24.04' || matrix.platform == 'linux-arm64' && 'ubuntu-24.04-arm' }}
     name: "Build platform ${{ matrix.platform }} golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Clean disk space
         uses: ./.github/actions/clean-runner
       - uses: benjlevesque/short-sha@v2.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
       - uses: benjlevesque/short-sha@v3.0
         id: short-sha
       - name: Set up golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup Environment

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Clean disk space
         uses: ./.github/actions/clean-runner
-      - uses: benjlevesque/short-sha@v2.1
+      - uses: benjlevesque/short-sha@v3.0
         id: short-sha
       - name: Set up golang ${{ matrix.go-version }}
         uses: actions/setup-go@v5

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
       - name: Check out source code

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: 1.25.10
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install go
       uses: actions/setup-go@v5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.25.10
 

--- a/.github/workflows/commit-msg.yaml
+++ b/.github/workflows/commit-msg.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -50,7 +50,7 @@ jobs:
         privilege-level: ${{fromJson(inputs.privilege-level)}}
     name: "golang ${{ matrix.go-version }} privilege ${{ matrix.privilege-level }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Clean disk space
         uses: ./.github/actions/clean-runner
       - uses: benjlevesque/short-sha@v2.1

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Clean disk space
         uses: ./.github/actions/clean-runner
-      - uses: benjlevesque/short-sha@v2.1
+      - uses: benjlevesque/short-sha@v3.0
         id: short-sha
       - name: Set up golang ${{ matrix.go-version }}
         uses: actions/setup-go@v5

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -117,7 +117,7 @@ jobs:
           name: binary-cov
           path: stacker
           if-no-files-found: error
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: restore-build
         with:
           path: stacker

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: benjlevesque/short-sha@v3.0
         id: short-sha
       - name: Set up golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup Environment

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -110,7 +110,7 @@ jobs:
           token: ${{ secrets.codecov_token }}
           files: coverage-${{ matrix.privilege-level}}.txt
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ (matrix.privilege-level == 'priv') }}
         with:
           # if there is more than 1 go-version, we would need to account for that here.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,7 +11,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python 3.x
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Check DCO

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       build-id: ${{steps.build-id.outputs.build-id}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: benjlevesque/short-sha@v2.1
         id: short-sha
       - id: build-id

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       build-id: ${{steps.build-id.outputs.build-id}}
     steps:
       - uses: actions/checkout@v7
-      - uses: benjlevesque/short-sha@v2.1
+      - uses: benjlevesque/short-sha@v3.0
         id: short-sha
       - id: build-id
         run: echo "build-id=${{ github.event.release.tag_name }}-${{ steps.short-sha.outputs.sha }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
     # needs ci for the cached stacker binary
     needs: [build-id, ci]
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: restore-build
         with:
           path: stacker-${{ matrix.platform }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

Updates older github actions that used Node 20 to versions that use Node 24
Closes #761

**What does this PR do / Why do we need it**:

Keeping actions current ensures we don't get broken builds or other problems


**Testing done on this change**:

None, all testing happens during CI on github

**Automation added to e2e**:

None

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
