### PR TITLE
fix: stacker convert should include ENV vars into runtime config.

### DIFF
--- a/pkg/stacker/convert.go
+++ b/pkg/stacker/convert.go
@@ -176,6 +176,14 @@ func (c *Converter) convertCommand(cmd *Command) error {
 			c.env = map[string]string{}
 		}
 
+		// Dockerfile ENV defines build and runtime variables.
+		// For equivalent in stacker, also add them to layer's
+		// Environment(runtime).
+		//
+		if layer.Environment == nil {
+			layer.Environment = map[string]string{}
+		}
+
 		// parser returns key, value, sep for ENV since v0.16.1
 		// https://github.com/moby/buildkit/commit/6cfa4599029db7f2e6e83feaaa33984785ddd147
 		if len(cmd.Value) < 3 {
@@ -211,7 +219,12 @@ func (c *Converter) convertCommand(cmd *Command) error {
 				c.env = map[string]string{}
 			}
 
+			if layer.Environment == nil {
+				layer.Environment = map[string]string{}
+			}
+
 			c.env[key] = val
+			layer.Environment[key] = val
 		}
 	case "workdir":
 		layer.Run = append(layer.Run, fmt.Sprintf("mkdir -p %s", cmd.Value[0]))

--- a/pkg/stacker/convert_test.go
+++ b/pkg/stacker/convert_test.go
@@ -22,8 +22,13 @@ func TestConverterConvertCommandErrors(t *testing.T) {
 		},
 		{
 			name: "invalid env",
-			c:    NewConverter(&ConvertArgs{}),
-			cmd:  &Command{Cmd: "env", Original: "ENV FOO", Value: []string{"FOO"}},
+			c: func() *Converter {
+				c := NewConverter(&ConvertArgs{})
+				c.currLayer = "layer"
+				c.output[c.currLayer] = &types.Layer{}
+				return c
+			}(),
+			cmd: &Command{Cmd: "env", Original: "ENV FOO", Value: []string{"FOO"}},
 		},
 		{
 			name: "invalid arg",


### PR DESCRIPTION
Dockerfile ENV defines variables for both build and runtime. Stacker convert, converts ENV for build, but does not include runtime. Stacker uses "environment:" in yaml to define variables for runtime. So, include the ENV variables there so they will show up in the config when running the container.

See https://docs.docker.com/reference/dockerfile/#env

**What type of PR is this?**
bug

**Which issue does this PR fix**:
#757 

**What does this PR do / Why do we need it**:
See above.

**If an issue # is not available please add repro steps and logs showing the issue**:
See issue #757.
1. Dockerfile contents:
```
FROM alpine AS mybase
ENV HELLO=hello!
ENV GOODBYE=goodbye!
RUN echo $HELLO && \
    echo $GOODBYE
```
2. Converted stacker.yaml
```
mybase:
  build_env:
    arch: amd64
  from:
    type: docker
    url: docker://alpine
  run:
  - export HELLO=hello!
  - export GOODBYE=goodbye!
  - sh -e -c 'echo $HELLO &&     echo $GOODBYE'
```
3. Using skopeo inspect
```
"Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ]
```
Note: env does not include HELLO and GOODBYE in image.

**Testing done on this change**:
- CI
- Manual
1. Dockerfile contents:
```
FROM alpine AS mybase
ENV HELLO=hello!
ENV GOODBYE=goodbye!
RUN echo $HELLO && \
    echo $GOODBYE
```

5. Converted stacker.yaml contents
```
mybase:
  build_env:
    arch: amd64
  environment:
    GOODBYE: goodbye!
    HELLO: hello!
  from:
    type: docker
    url: docker://alpine
  run:
  - export HELLO=hello!
  - export GOODBYE=goodbye!
  - sh -e -c 'echo $HELLO &&     echo $GOODBYE'
```

6.  Using skopeo inspect,
```
"Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "GOODBYE=goodbye!",
        "HELLO=hello!"
    ]
```

**Automation added to e2e**:
None

**Will this break upgrades or downgrades?**
No. 

**Does this PR introduce any user-facing change?**:
Yes, but only for converted Dockerfiles. The resulting stacker.yaml file will now include an environment section if there were any ENVs in the Dockerfile. This will cause the image runtime to include the environment variables in any ENVs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
